### PR TITLE
fix: cross-compilation linker in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,13 @@ jobs:
             # Install cross-compilation toolchain for linux-arm64
             sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
             rustup target add aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
-            mkdir -p ~/.cargo
-            echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config.toml
-            echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml
 
-            # Build all Linux targets
+            # Build linux-x64 (native)
             cargo build --release --target x86_64-unknown-linux-gnu -p devpod-mcp
-            cargo build --release --target aarch64-unknown-linux-gnu -p devpod-mcp
+
+            # Build linux-arm64 (cross-compile with correct linker)
+            CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+              cargo build --release --target aarch64-unknown-linux-gnu -p devpod-mcp
 
             # Copy binaries to output dir
             mkdir -p /tmp/release


### PR DESCRIPTION
Fixes the aarch64 cross-compilation failure in the release workflow.

**Problem:** `~/.cargo/config.toml` linker config wasn't being picked up inside the devcontainer because `CARGO_HOME` points to `/usr/local/cargo`, not `~/.cargo`.

**Fix:** Use the `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER` env var instead — this always works regardless of cargo home location.