### PR TITLE
Fix WSL install script: use wsl -e /bin/bash to avoid /bin/sh PATH issues

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -44,14 +44,45 @@ try {
     exit 1
 }
 
+# Find usable WSL distros (skip docker-desktop* distros which are minimal)
+$WslDistro = $null
+$distroLines = (wsl -l -q 2>&1) -replace "`0", "" | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+$usableDistros = @($distroLines | Where-Object { $_ -notmatch '^docker-desktop' })
+
+if ($usableDistros.Count -eq 0) {
+    Write-Host ""
+    Write-Host "Error: No usable WSL distro found (docker-desktop is not supported)." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Install a Linux distro with:  wsl --install Ubuntu" -ForegroundColor Yellow
+    exit 1
+} elseif ($usableDistros.Count -eq 1) {
+    $WslDistro = $usableDistros[0]
+} else {
+    Write-Host ""
+    Write-Host "Available WSL distros:" -ForegroundColor Cyan
+    for ($i = 0; $i -lt $usableDistros.Count; $i++) {
+        Write-Host "  [$($i + 1)] $($usableDistros[$i])"
+    }
+    Write-Host ""
+    $choice = Read-Host "Select a distro (1-$($usableDistros.Count))"
+    $idx = [int]$choice - 1
+    if ($idx -lt 0 -or $idx -ge $usableDistros.Count) {
+        Write-Host "Invalid selection." -ForegroundColor Red
+        exit 1
+    }
+    $WslDistro = $usableDistros[$idx]
+}
+
+Write-Ok "Using WSL distro: $WslDistro"
+
 # ---------------------------------------------------------------------------
-# 2. Install binary inside WSL (reuse install.sh)
+# 2. Install binary inside WSL
 # ---------------------------------------------------------------------------
 
 Write-Step "Installing devcontainer-mcp binary inside WSL..."
 
 $installUrl = "https://raw.githubusercontent.com/$Repo/main/install.sh"
-$wslResult = wsl bash -c "curl -fsSL '$installUrl' | bash -s -- --skip-mcp-config" 2>&1
+$wslResult = wsl -d $WslDistro bash -c "curl -fsSL '$installUrl' | bash -s -- --skip-mcp-config" 2>&1
 $wslResult | ForEach-Object { Write-Host "    $_" }
 
 if ($LASTEXITCODE -ne 0) {
@@ -62,7 +93,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # Verify the binary works
-$versionCheck = wsl bash -lc "$WslBinaryPath --version" 2>&1
+$versionCheck = wsl -d $WslDistro bash -lc "$WslBinaryPath --version" 2>&1
 if ($LASTEXITCODE -eq 0) {
     Write-Ok "Installed: $($versionCheck.Trim())"
 } else {
@@ -101,12 +132,12 @@ Write-Host "Backend CLIs detected in WSL (install as needed — MCP server gives
 
 $backends = @(
     @{ Name = "devpod";       Url = "https://devpod.sh/docs/getting-started/install" }
-    @{ Name = "devcontainer"; Url = "npm install -g @devcontainers/cli" }
+    @{ Name = "devcontainer"; Url = "https://github.com/devcontainers/cli#install-script" }
     @{ Name = "gh";           Url = "https://cli.github.com/" }
 )
 
 foreach ($b in $backends) {
-    $check = wsl bash -lc "command -v $($b.Name)" 2>&1
+    $check = wsl -d $WslDistro bash -lc "command -v $($b.Name)" 2>&1
     if ($LASTEXITCODE -eq 0) {
         Write-Ok "$($b.Name)"
     } else {

--- a/install.sh
+++ b/install.sh
@@ -120,7 +120,7 @@ done
 echo ""
 echo "Backend CLIs detected (install as needed — MCP server gives helpful errors if missing):"
 command -v devpod       >/dev/null 2>&1 && echo "  ✓ devpod"       || echo "  ✗ devpod        — https://devpod.sh/docs/getting-started/install"
-command -v devcontainer >/dev/null 2>&1 && echo "  ✓ devcontainer"  || echo "  ✗ devcontainer   — npm install -g @devcontainers/cli"
+command -v devcontainer >/dev/null 2>&1 && echo "  ✓ devcontainer"  || echo "  ✗ devcontainer   — https://github.com/devcontainers/cli#install-script"
 command -v gh           >/dev/null 2>&1 && echo "  ✓ gh (codespaces)" || echo "  ✗ gh (codespaces) — https://cli.github.com/"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`wsl bash -c` routes through `/bin/sh`, which may not have `bash` in its PATH on minimal WSL distros. This causes the install to fail with:

```
wsl : /bin/sh: bash: not found
```

Fix: use `wsl -e /bin/bash` to invoke bash directly, bypassing the default shell. Applied to all three WSL invocations in the script.