### PR TITLE
Enhance README with demo GIFs, client compatibility, and hardware scaling point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # devcontainer-mcp
 
 [![CI](https://github.com/aniongithub/devcontainer-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/aniongithub/devcontainer-mcp/actions/workflows/ci.yml)
+[![Website](https://img.shields.io/badge/website-anonline.me-blue)](https://www.anonline.me/devcontainer-mcp)
 
 **Give your AI agent its own dev environment — not yours.**
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 `devcontainer-mcp` is an MCP server that lets AI coding agents create, manage, and work inside [dev containers](https://containers.dev/) across three backends: local Docker, [DevPod](https://devpod.sh/), and [GitHub Codespaces](https://github.com/features/codespaces). The agent builds, tests, and ships code in an isolated container — your laptop stays clean.
 
+<p align="center">
+  <img src="https://raw.githubusercontent.com/aniongithub/devcontainer-mcp/gh-pages/screengrabs/devcontainer-mcp-local-docker.gif" alt="devcontainer-mcp local Docker demo" width="720">
+</p>
+
+> Works with **GitHub Copilot**, **Claude**, **Cursor**, and any MCP-compatible client.
+
 ## The Problem
 
 When AI agents write code, they need to run it somewhere. Today that means your host machine:
@@ -14,6 +20,7 @@ When AI agents write code, they need to run it somewhere. Today that means your 
 - 🔴 **"Works on my machine"** — agents assume your local toolchain matches production
 - 🔴 **No isolation** — one project's dependencies break another
 - 🔴 **Security risk** — agents run arbitrary commands with your user privileges
+- 🔴 **Hardware constraints** — you're limited to your local machine's resources
 
 ## The Solution
 
@@ -35,6 +42,10 @@ Agent: "Let me build this project..."
 ```
 
 ## Quick Install
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/aniongithub/devcontainer-mcp/gh-pages/screengrabs/devcontainer-mcp-install.gif" alt="devcontainer-mcp install demo" width="720">
+</p>
 
 ### Linux / macOS
 
@@ -78,6 +89,10 @@ graph TD
 ```
 
 ## Three Backends, One Interface
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/aniongithub/devcontainer-mcp/gh-pages/screengrabs/devcontainer-mcp-codespaces.gif" alt="devcontainer-mcp Codespaces demo" width="720">
+</p>
 
 | Backend | Best for | Requires | Auth needed? |
 |---------|----------|----------|:---:|

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # devcontainer-mcp
 
 [![CI](https://github.com/aniongithub/devcontainer-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/aniongithub/devcontainer-mcp/actions/workflows/ci.yml)
-[![Website](https://img.shields.io/badge/website-anonline.me-blue)](https://www.anonline.me/devcontainer-mcp)
+[![Website](https://img.shields.io/badge/website-devcontainer--mcp-blue)](https://www.anonline.me/devcontainer-mcp)
 
 **Give your AI agent its own dev environment — not yours.**
 


### PR DESCRIPTION
Pulls content from the gh-pages website to make the README more engaging:

- **Hero GIF** — local Docker workflow demo right below the tagline
- **"Works with" line** — GitHub Copilot, Claude, Cursor compatibility
- **Install GIF** — installation demo above the install commands
- **Codespaces GIF** — demo in the Three Backends section
- **Hardware constraints** — added to the problem list (scaling angle)