### PR TITLE
Replace split_whitespace with shlex for shell-aware argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "shlex",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -319,7 +320,7 @@ dependencies = [
  "futures-util",
  "serde",
  "serde_json",
- "shell-escape",
+ "shlex",
  "thiserror",
  "tokio",
  "tracing",
@@ -1188,12 +1189,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shell-escape"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shlex"

--- a/crates/devcontainer-mcp-core/Cargo.toml
+++ b/crates/devcontainer-mcp-core/Cargo.toml
@@ -16,4 +16,4 @@ tracing = { workspace = true }
 futures-util = "0.3"
 async-trait = "0.1"
 base64 = "0.22"
-shell-escape = "0.1"
+shlex = "1"

--- a/crates/devcontainer-mcp-core/src/file_ops.rs
+++ b/crates/devcontainer-mcp-core/src/file_ops.rs
@@ -4,10 +4,7 @@
 //! formatting, and helpers to build shell commands for reading/writing files
 //! through any backend (DevPod SSH, devcontainer exec, Codespaces SSH).
 
-use std::borrow::Cow;
-
 use base64::{engine::general_purpose::STANDARD, Engine};
-use shell_escape::escape;
 
 use crate::error::{Error, Result};
 
@@ -57,7 +54,9 @@ pub fn apply_edit(content: &str, old_str: &str, new_str: &str) -> Result<String>
 
 /// Shell-escape a string for safe embedding in a shell command.
 fn quote(s: &str) -> String {
-    escape(Cow::Borrowed(s)).into_owned()
+    shlex::try_quote(s)
+        .unwrap_or(std::borrow::Cow::Borrowed(s))
+        .into_owned()
 }
 
 /// Build a shell command that reads a file via `cat`.
@@ -133,8 +132,11 @@ mod tests {
     #[test]
     fn test_quote_path_with_single_quote() {
         let result = quote("it's");
-        // Should not break when used in a shell command
-        assert!(!result.contains("it's") || result.contains("\\'"));
+        // Result should be shell-safe: either escaped or wrapped in quotes
+        assert!(
+            result != "it's",
+            "single quote must be escaped or quoted, got: {result}"
+        );
     }
 
     #[test]

--- a/crates/devcontainer-mcp/Cargo.toml
+++ b/crates/devcontainer-mcp/Cargo.toml
@@ -17,3 +17,4 @@ rmcp = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 schemars = "1"
+shlex = "1"

--- a/crates/devcontainer-mcp/src/tools/devcontainer/build.rs
+++ b/crates/devcontainer-mcp/src/tools/devcontainer/build.rs
@@ -25,12 +25,13 @@ impl DevContainerMcp {
         &self,
         Parameters(params): Parameters<DevcontainerBuildParams>,
     ) -> String {
-        let extra: Vec<&str> = params
+        let extra: Vec<String> = params
             .extra_args
             .as_deref()
-            .map(|a| a.split_whitespace().collect())
+            .and_then(shlex::split)
             .unwrap_or_default();
-        match devcontainer::build(&params.workspace_folder, &extra).await {
+        let extra_refs: Vec<&str> = extra.iter().map(|s| s.as_str()).collect();
+        match devcontainer::build(&params.workspace_folder, &extra_refs).await {
             Ok(output) => format_output(&output),
             Err(e) => format!("Error: {e}"),
         }

--- a/crates/devcontainer-mcp/src/tools/devcontainer/exec.rs
+++ b/crates/devcontainer-mcp/src/tools/devcontainer/exec.rs
@@ -25,12 +25,11 @@ impl DevContainerMcp {
         &self,
         Parameters(params): Parameters<DevcontainerExecParams>,
     ) -> String {
-        let cmd_args: Vec<&str> = params
-            .args
-            .as_deref()
-            .map(|a| a.split_whitespace().collect())
-            .unwrap_or_default();
-        match devcontainer::exec(&params.workspace_folder, &params.command, &cmd_args).await {
+        let full_cmd = match &params.args {
+            Some(a) => format!("{} {}", params.command, a),
+            None => params.command,
+        };
+        match devcontainer::exec(&params.workspace_folder, "sh", &["-c", &full_cmd]).await {
             Ok(output) => format_output(&output),
             Err(e) => format!("Error: {e}"),
         }

--- a/crates/devcontainer-mcp/src/tools/devcontainer/up.rs
+++ b/crates/devcontainer-mcp/src/tools/devcontainer/up.rs
@@ -29,12 +29,19 @@ impl DevContainerMcp {
         &self,
         Parameters(params): Parameters<DevcontainerUpParams>,
     ) -> String {
-        let extra: Vec<&str> = params
+        let extra: Vec<String> = params
             .extra_args
             .as_deref()
-            .map(|a| a.split_whitespace().collect())
+            .and_then(shlex::split)
             .unwrap_or_default();
-        match devcontainer::up(&params.workspace_folder, params.config.as_deref(), &extra).await {
+        let extra_refs: Vec<&str> = extra.iter().map(|s| s.as_str()).collect();
+        match devcontainer::up(
+            &params.workspace_folder,
+            params.config.as_deref(),
+            &extra_refs,
+        )
+        .await
+        {
             Ok(output) => format_output(&output),
             Err(e) => format!("Error: {e}"),
         }

--- a/crates/devcontainer-mcp/src/tools/devpod/build.rs
+++ b/crates/devcontainer-mcp/src/tools/devpod/build.rs
@@ -19,8 +19,10 @@ impl DevContainerMcp {
         description = "Build a DevPod workspace image without starting it."
     )]
     async fn devpod_build(&self, Parameters(params): Parameters<DevpodBuildParams>) -> String {
-        let parts: Vec<&str> = params.args.split_whitespace().collect();
-        match devpod::build(&parts).await {
+        let parts: Vec<String> = shlex::split(&params.args)
+            .unwrap_or_else(|| params.args.split_whitespace().map(String::from).collect());
+        let part_refs: Vec<&str> = parts.iter().map(|s| s.as_str()).collect();
+        match devpod::build(&part_refs).await {
             Ok(output) => format_output(&output),
             Err(e) => format!("Error: {e}"),
         }

--- a/crates/devcontainer-mcp/src/tools/devpod/provider.rs
+++ b/crates/devcontainer-mcp/src/tools/devpod/provider.rs
@@ -37,12 +37,13 @@ impl DevContainerMcp {
         &self,
         Parameters(params): Parameters<DevpodProviderAddParams>,
     ) -> String {
-        let opt_parts: Vec<&str> = params
+        let opt_parts: Vec<String> = params
             .options
             .as_deref()
-            .map(|o| o.split_whitespace().collect())
+            .and_then(shlex::split)
             .unwrap_or_default();
-        match devpod::provider_add(&params.provider, &opt_parts).await {
+        let opt_refs: Vec<&str> = opt_parts.iter().map(|s| s.as_str()).collect();
+        match devpod::provider_add(&params.provider, &opt_refs).await {
             Ok(output) => format_output(&output),
             Err(e) => format!("Error: {e}"),
         }

--- a/crates/devcontainer-mcp/src/tools/devpod/up.rs
+++ b/crates/devcontainer-mcp/src/tools/devpod/up.rs
@@ -19,8 +19,10 @@ impl DevContainerMcp {
         description = "Create and start a DevPod workspace. Pass the source (git URL, local path, or image) and any flags as space-separated args. Returns full build output for self-healing."
     )]
     async fn devpod_up(&self, Parameters(params): Parameters<DevpodUpParams>) -> String {
-        let parts: Vec<&str> = params.args.split_whitespace().collect();
-        match devpod::up(&parts).await {
+        let parts: Vec<String> = shlex::split(&params.args)
+            .unwrap_or_else(|| params.args.split_whitespace().map(String::from).collect());
+        let part_refs: Vec<&str> = parts.iter().map(|s| s.as_str()).collect();
+        match devpod::up(&part_refs).await {
             Ok(output) => format_output(&output),
             Err(e) => format!("Error: {e}"),
         }


### PR DESCRIPTION
## Summary

Replaces naive `split_whitespace()` argument splitting with the `shlex` crate for proper shell-aware parsing across all tools. Also replaces `shell-escape` with `shlex` for quoting (one crate for both directions).

Fixes #10, fixes #15

## Changes

### `devcontainer_exec` — always wrap in `sh -c`

The agent passes commands exactly like it would on the host:
```
devcontainer_exec(workspace_folder: "/path", command: "cargo build")
devcontainer_exec(workspace_folder: "/path", command: "cd /foo && npm test")
devcontainer_exec(workspace_folder: "/path", command: "git commit -m \"my message\"")
```

We handle the hard bits — no need for the agent to split command/args or worry about quoting. This matches how `devpod_ssh` and `codespaces_ssh` already work.

### 5 other tools — `shlex::split()` for CLI flags

`devcontainer_up`, `devcontainer_build`, `devpod_up`, `devpod_build`, `devpod_provider_add` now use `shlex::split()` instead of `split_whitespace()` so quoted values in extra args are preserved.

### `file_ops` — `shlex::try_quote()` replaces `shell_escape`

Removes the `shell-escape` dependency. `shlex` handles both splitting and quoting.

## Why

The design goal is simplicity for the agent: pass a command string, we handle the rest. Imposing quoting/splitting rules on agents makes it harder for smaller models to work correctly.