### PR TITLE
Add opencode skill + MCP server installation to installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <img src="https://raw.githubusercontent.com/aniongithub/devcontainer-mcp/gh-pages/screengrabs/devcontainer-mcp-local-docker.gif" alt="devcontainer-mcp local Docker demo" width="720">
 </p>
 
-> Works with **GitHub Copilot**, **Claude**, **Cursor**, and any MCP-compatible client.
+> Works with **GitHub Copilot**, **Claude**, **Cursor**, **opencode**, and any MCP-compatible client.
 
 ## The Problem
 

--- a/install.ps1
+++ b/install.ps1
@@ -111,6 +111,7 @@ $skillDirs = @(
     "$env:USERPROFILE\.copilot\skills\devcontainer-mcp"
     "$env:USERPROFILE\.claude\skills\devcontainer-mcp"
     "$env:USERPROFILE\.agents\skills\devcontainer-mcp"
+    "$env:USERPROFILE\.config\opencode\skills\devcontainer-mcp"
 )
 
 foreach ($dir in $skillDirs) {
@@ -361,6 +362,48 @@ if (Test-Path $vscodeDir) {
 if (Test-Path "$env:USERPROFILE\.cursor") {
     Set-McpConfig "$env:USERPROFILE\.cursor\mcp.json" "Cursor"
 }
+
+# opencode — uses a distinct schema (mcp key, type: "local", combined
+# command array, enabled: true) and lives at ~/.config/opencode/opencode.json.
+function Set-OpencodeMcpConfig {
+    $ConfigPath = "$env:USERPROFILE\.config\opencode\opencode.json"
+    $opencodeEntry = [PSCustomObject]@{
+        type    = "local"
+        command = @("wsl", $WslBinaryPath, "serve")
+        enabled = $true
+    }
+
+    try {
+        if (Test-Path $ConfigPath) {
+            $content = Get-Content -Raw $ConfigPath | ConvertFrom-Json
+            if (-not $content.mcp) {
+                $content | Add-Member -NotePropertyName "mcp" -NotePropertyValue ([PSCustomObject]@{})
+            }
+            if ($content.mcp.PSObject.Properties.Name -contains "devcontainer-mcp") {
+                Write-Ok "opencode — already configured"
+                return
+            }
+            $content.mcp | Add-Member -NotePropertyName "devcontainer-mcp" -NotePropertyValue $opencodeEntry
+            $content | ConvertTo-Json -Depth 10 | Set-Content $ConfigPath -Encoding UTF8
+            Write-Ok "opencode — added to $ConfigPath"
+        } else {
+            $dir = Split-Path $ConfigPath -Parent
+            if ($dir) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+            $config = [PSCustomObject]@{
+                '$schema' = "https://opencode.ai/config.json"
+                mcp = [PSCustomObject]@{
+                    "devcontainer-mcp" = $opencodeEntry
+                }
+            }
+            $config | ConvertTo-Json -Depth 10 | Set-Content $ConfigPath -Encoding UTF8
+            Write-Ok "opencode — created $ConfigPath"
+        }
+    } catch {
+        Write-Warn "opencode — could not update $ConfigPath"
+    }
+}
+
+Set-OpencodeMcpConfig
 
 # ---------------------------------------------------------------------------
 # Done

--- a/install.sh
+++ b/install.sh
@@ -106,6 +106,7 @@ SKILL_DIRS=(
   "${HOME}/.copilot/skills/devcontainer-mcp"
   "${HOME}/.claude/skills/devcontainer-mcp"
   "${HOME}/.agents/skills/devcontainer-mcp"
+  "${HOME}/.config/opencode/skills/devcontainer-mcp"
 )
 
 echo ""
@@ -346,6 +347,51 @@ else:
   fi
 }
 
+# opencode uses a different config schema (mcp key, type: "local", combined
+# command array, enabled: true) and a different file path.
+configure_opencode_mcp() {
+  local config_file="${HOME}/.config/opencode/opencode.json"
+  local bin_path="${INSTALL_DIR}/devcontainer-mcp"
+
+  if [ ! -f "$config_file" ]; then
+    mkdir -p "$(dirname "$config_file")"
+    cat > "$config_file" << OPENCODEEOF
+{
+  "\$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "devcontainer-mcp": {
+      "type": "local",
+      "command": ["${bin_path}", "serve"],
+      "enabled": true
+    }
+  }
+}
+OPENCODEEOF
+    echo "  ✓ opencode — created ${config_file}"
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c "
+import json
+path = '${config_file}'
+with open(path) as f:
+    data = json.load(f)
+servers = data.setdefault('mcp', {})
+if 'devcontainer-mcp' not in servers:
+    servers['devcontainer-mcp'] = {
+        'type': 'local',
+        'command': ['${bin_path}', 'serve'],
+        'enabled': True,
+    }
+    with open(path, 'w') as f:
+        json.dump(data, f, indent=2)
+    print('  ✓ opencode — added to ${config_file}')
+else:
+    print('  ✓ opencode — already configured')
+" 2>/dev/null || echo "  ⚠ opencode — could not update ${config_file}"
+  else
+    echo "  ⚠ opencode — exists but python3 not available to merge"
+  fi
+}
+
 echo ""
 echo "==> Configuring MCP clients..."
 
@@ -371,6 +417,9 @@ fi
 
 # Claude Code — ~/.claude.json
 configure_mcp_client "${HOME}/.claude.json" "Claude Code"
+
+# opencode — ~/.config/opencode/opencode.json (uses different schema)
+configure_opencode_mcp
 
 echo ""
 echo "Done! devcontainer-mcp is ready to use."


### PR DESCRIPTION
## Summary

Adds opencode (https://opencode.ai) as a first-class target in both installers, alongside the existing GitHub Copilot CLI, Claude Code, VS Code, and Cursor support.

## Why

opencode is gaining traction as an MCP-compatible coding agent. Until now, users had to hand-edit `~/.config/opencode/opencode.json` after running the installer. This PR makes it just work.

## What changed

opencode reads MCP configuration from `~/.config/opencode/opencode.json` using a **distinct schema** from the `mcpServers` convention used by every other client we support:

- top-level key is `mcp` (not `mcpServers`)
- requires `"type": "local"`
- `command` is a **single array** (binary + args combined) — not separate `command` string + `args` array
- explicit `"enabled": true`

That meant a dedicated config function in each installer rather than reusing the existing `configure_mcp_client` / `Set-McpConfig` helpers.

### `install.sh`
- Add `~/.config/opencode/skills/devcontainer-mcp` to `SKILL_DIRS` so `SKILL.md` lands at opencode's documented global skills path.
- New `configure_opencode_mcp` function. Creates the file if missing; otherwise merges via python3 — preserves any existing `$schema`, `model`, sibling MCP entries, and other settings.

### `install.ps1`
- Mirror the skill directory addition.
- New `Set-OpencodeMcpConfig` that writes the WSL-bridge form: `command: ["wsl", "~/.local/bin/devcontainer-mcp", "serve"]`.

### `README.md`
- List opencode in the "Works with" badge line.

## Scope note: host-protection hooks

opencode does have a hook mechanism, but it works very differently from Claude Code's `PreToolUse` / `SessionStart` (JSON pointing at a shell script). opencode uses a **JS/TS plugin system** ([docs](https://opencode.ai/docs/plugins/)) where plugins live in `~/.config/opencode/plugins/` and subscribe to events like `tool.execute.before` and `session.created`.

Wiring our `devcontainer-guard.sh` and `devcontainer-skill-loader.sh` into that model requires writing a thin JS plugin that spawns the existing bash hooks — out of scope for this PR. Tracked as a follow-up issue.

## Verification

Spun up the project's own devcontainer (debian-bookworm + rust + node + docker-in-docker) and ran `install.sh` inside. All checks pass:

| Test | Result |
|---|---|
| Fresh-install creates `~/.config/opencode/opencode.json` with valid schema | ✅ |
| `SKILL.md` placed at `~/.config/opencode/skills/devcontainer-mcp/` | ✅ |
| Schema validated: `$schema`, `mcp.devcontainer-mcp.{type,command,enabled}` correct | ✅ |
| Idempotent rerun → "opencode — already configured" | ✅ |
| Merge into pre-existing config preserves `$schema`, `model`, and a sibling MCP entry | ✅ |
| Binary at the configured `command[0]` launches correctly (`devcontainer-mcp --help` succeeds) | ✅ |

Sample of the file the installer produces:

```json
{
  "$schema": "https://opencode.ai/config.json",
  "mcp": {
    "devcontainer-mcp": {
      "type": "local",
      "command": ["/home/vscode/.local/bin/devcontainer-mcp", "serve"],
      "enabled": true
    }
  }
}
```
