### PR TITLE
Stream output, honor cancellation, and reap remote process trees across all three backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ name = "devcontainer-mcp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "devcontainer-mcp-core",
  "rmcp",
@@ -306,6 +307,7 @@ dependencies = [
  "serde_json",
  "shlex",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
 ]
@@ -318,11 +320,13 @@ dependencies = [
  "base64",
  "bollard",
  "futures-util",
+ "libc",
  "serde",
  "serde_json",
  "shlex",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -364,10 +365,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -467,10 +480,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -713,6 +748,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,10 +832,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -936,6 +989,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +1015,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "redox_syscall"
@@ -1035,6 +1104,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1171,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1264,6 +1352,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1457,6 +1558,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1609,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1669,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -1634,6 +1793,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/crates/devcontainer-mcp-core/Cargo.toml
+++ b/crates/devcontainer-mcp-core/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 tokio = { workspace = true }
+tokio-util = "0.7"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -17,3 +18,6 @@ futures-util = "0.3"
 async-trait = "0.1"
 base64 = "0.22"
 shlex = "1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/crates/devcontainer-mcp-core/Cargo.toml
+++ b/crates/devcontainer-mcp-core/Cargo.toml
@@ -21,3 +21,6 @@ shlex = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/devcontainer-mcp-core/src/cli.rs
+++ b/crates/devcontainer-mcp-core/src/cli.rs
@@ -1,7 +1,10 @@
 use serde::Serialize;
 use std::collections::HashMap;
 use std::process::Stdio;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
+use tokio_util::sync::CancellationToken;
 
 use crate::error::{Error, Result};
 
@@ -57,8 +60,38 @@ impl CliBinary {
     }
 }
 
+/// Which output stream a chunk came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputStream {
+    Stdout,
+    Stderr,
+}
+
+/// A chunk of output from a streaming CLI invocation.
+#[derive(Debug, Clone)]
+pub struct OutputChunk {
+    pub stream: OutputStream,
+    /// One line of output (without trailing newline).
+    pub line: String,
+}
+
+/// Sink for streamed output chunks.
+///
+/// Implementations should be fast — they're awaited inline by the
+/// background dispatcher and slow sinks will buffer up in the bounded
+/// channel. Errors must be swallowed inside the sink (we don't want to
+/// abort the underlying process because progress reporting failed).
+#[async_trait::async_trait]
+pub trait ChunkSink: Send + Sync + 'static {
+    async fn on_chunk(&self, chunk: OutputChunk);
+}
+
 /// Run a CLI command, capturing stdout/stderr/exit_code.
 /// If `parse_json` is true, attempts to parse stdout as JSON.
+///
+/// Convenience wrapper around [`run_cli_streaming`] with no progress sink
+/// and a fresh (never-fired) cancellation token. Callers that want
+/// cancellation or progress should use [`run_cli_streaming`] directly.
 pub async fn run_cli(binary: &CliBinary, args: &[&str], parse_json: bool) -> Result<CliOutput> {
     run_cli_with_env(binary, args, parse_json, None).await
 }
@@ -70,8 +103,47 @@ pub async fn run_cli_with_env(
     parse_json: bool,
     env: Option<&HashMap<String, String>>,
 ) -> Result<CliOutput> {
+    run_cli_streaming(
+        binary,
+        args,
+        parse_json,
+        env,
+        &CancellationToken::new(),
+        None,
+    )
+    .await
+}
+
+/// Run a CLI command with full control over cancellation and progress.
+///
+/// - `cancel`: if cancelled while the child is running, the child is killed
+///   (SIGTERM, then SIGKILL after a 2s grace period via `kill_on_drop`)
+///   and [`Error::Cancelled`] is returned. Any output produced before
+///   cancellation is forwarded to the sink but discarded from the return
+///   value.
+/// - `on_chunk`: optional sink invoked for every line of stdout/stderr as
+///   it arrives. Useful for emitting MCP progress notifications.
+///
+/// Regardless of streaming, the full stdout/stderr is also accumulated
+/// and returned in [`CliOutput`] for callers that need the final result.
+pub async fn run_cli_streaming(
+    binary: &CliBinary,
+    args: &[&str],
+    parse_json: bool,
+    env: Option<&HashMap<String, String>>,
+    cancel: &CancellationToken,
+    on_chunk: Option<Arc<dyn ChunkSink>>,
+) -> Result<CliOutput> {
     let mut cmd = Command::new(binary.command_name());
-    cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
+    cmd.args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        // Belt-and-braces: if this future is dropped (e.g. caller bails
+        // before we finish handling cancel), tokio will SIGKILL the
+        // child for us. Without this, a cancelled but un-awaited child
+        // would survive as a zombie / runaway process.
+        .kill_on_drop(true);
 
     if let Some(env_vars) = env {
         for (k, v) in env_vars {
@@ -79,7 +151,7 @@ pub async fn run_cli_with_env(
         }
     }
 
-    let output = cmd.output().await.map_err(|e| {
+    let mut child = cmd.spawn().map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
             binary.not_found_error()
         } else {
@@ -87,20 +159,104 @@ pub async fn run_cli_with_env(
         }
     })?;
 
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = child.stdout.take().expect("stdout was piped");
+    let stderr = child.stderr.take().expect("stderr was piped");
+
+    let stdout_task = tokio::spawn(drain_stream(
+        stdout,
+        OutputStream::Stdout,
+        on_chunk.clone(),
+    ));
+    let stderr_task = tokio::spawn(drain_stream(
+        stderr,
+        OutputStream::Stderr,
+        on_chunk.clone(),
+    ));
+
+    // Wait for either: child exits, or cancellation fires.
+    let status = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            tracing::warn!(
+                bin = binary.command_name(),
+                "cancellation received; reaping process tree"
+            );
+            // SIGTERM the entire descendant tree (including any
+            // in-container processes spawned via `devcontainer exec`
+            // → `docker exec` → containerd-shim). Container PID
+            // namespacing hides PIDs from each other but not from
+            // the host, so /proc walking sees through it.
+            if let Some(root_pid) = child.id() {
+                crate::process_tree::reap(root_pid, std::time::Duration::from_secs(2)).await;
+            }
+            // The root child should now be dead; wait briefly to
+            // collect its exit status and let the reader tasks observe
+            // EOF on stdout/stderr. `kill_on_drop(true)` is our
+            // backstop if any of this fails.
+            let _ = tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                child.wait(),
+            )
+            .await;
+            let _ = stdout_task.await;
+            let _ = stderr_task.await;
+            return Err(Error::Cancelled);
+        }
+        status = child.wait() => status?,
+    };
+
+    // Child exited; collect the accumulated output.
+    let stdout_buf = stdout_task.await.unwrap_or_default();
+    let stderr_buf = stderr_task.await.unwrap_or_default();
+    let exit_code = status.code().unwrap_or(-1);
 
     let json = if parse_json {
-        serde_json::from_str(&stdout).ok()
+        serde_json::from_str(&stdout_buf).ok()
     } else {
         None
     };
 
     Ok(CliOutput {
         exit_code,
-        stdout,
-        stderr,
+        stdout: stdout_buf,
+        stderr: stderr_buf,
         json,
     })
+}
+
+/// Read `reader` line-by-line, forwarding each line to `sink` (if set)
+/// and accumulating into the returned buffer. EOF or error ends the loop.
+async fn drain_stream<R: tokio::io::AsyncRead + Unpin + Send + 'static>(
+    reader: R,
+    stream: OutputStream,
+    sink: Option<Arc<dyn ChunkSink>>,
+) -> String {
+    let mut lines = BufReader::new(reader).lines();
+    let mut buf = String::new();
+    loop {
+        match lines.next_line().await {
+            Ok(Some(line)) => {
+                if !buf.is_empty() {
+                    buf.push('\n');
+                }
+                buf.push_str(&line);
+                if let Some(sink) = sink.as_ref() {
+                    sink.on_chunk(OutputChunk {
+                        stream,
+                        line,
+                    })
+                    .await;
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                tracing::debug!(%e, ?stream, "error reading child output stream");
+                break;
+            }
+        }
+    }
+    if !buf.is_empty() {
+        buf.push('\n');
+    }
+    buf
 }

--- a/crates/devcontainer-mcp-core/src/cli.rs
+++ b/crates/devcontainer-mcp-core/src/cli.rs
@@ -260,3 +260,351 @@ async fn drain_stream<R: tokio::io::AsyncRead + Unpin + Send + 'static>(
     }
     buf
 }
+
+/// Drain a stream that may contain the [`crate::exec_shim`] sentinel.
+///
+/// Lines matching `__DCMCP_PGID=N__` are intercepted: `N` is stored
+/// into `pgid_out` and the line is suppressed from both the sink and
+/// the accumulated buffer. All other lines flow through normally.
+async fn drain_stream_with_sentinel<R: tokio::io::AsyncRead + Unpin + Send + 'static>(
+    reader: R,
+    stream: OutputStream,
+    sink: Option<Arc<dyn ChunkSink>>,
+    pgid_out: Arc<std::sync::Mutex<Option<i32>>>,
+) -> String {
+    let mut lines = BufReader::new(reader).lines();
+    let mut buf = String::new();
+    loop {
+        match lines.next_line().await {
+            Ok(Some(line)) => {
+                if let Some(found) = crate::exec_shim::try_parse_sentinel(&line) {
+                    *pgid_out.lock().expect("pgid lock") = Some(found);
+                    tracing::debug!(pgid = found, ?stream, "captured remote PGID");
+                    continue;
+                }
+                if !buf.is_empty() {
+                    buf.push('\n');
+                }
+                buf.push_str(&line);
+                if let Some(sink) = sink.as_ref() {
+                    sink.on_chunk(OutputChunk { stream, line }).await;
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                tracing::debug!(%e, ?stream, "error reading child output stream");
+                break;
+            }
+        }
+    }
+    if !buf.is_empty() {
+        buf.push('\n');
+    }
+    buf
+}
+
+/// Trait for a backend-specific "send a kill into the remote target".
+///
+/// Used by [`run_with_shim`] to deliver SIGTERM/SIGKILL to a remote
+/// process group when cancellation fires. The runner calls this with
+/// the PGID captured from the shim's sentinel; the implementor knows
+/// how to reach into the target (docker exec, devpod ssh, gh ssh, …).
+///
+/// Implementations should be *idempotent* and *forgiving*: a kill of
+/// an already-exited process is fine, and the trait is invoked on a
+/// best-effort basis.
+#[async_trait::async_trait]
+pub trait RemoteKiller: Send + Sync {
+    /// Send `signal` (a POSIX signal name like "TERM" or "KILL") to
+    /// the entire process group `pgid` on the remote target.
+    async fn kill_pgid(&self, pgid: i32, signal: &str);
+}
+
+/// Run a CLI command whose remote target requires the [`crate::exec_shim`]
+/// shim for cancellation.
+///
+/// Differences from [`run_cli_streaming`]:
+///
+/// - The stderr reader filters out the sentinel line emitted by the
+///   shim and stores the captured remote PGID in shared state.
+/// - On cancel, before reaping the host-side process tree, the helper
+///   asks the supplied [`RemoteKiller`] to deliver SIGTERM then SIGKILL
+///   to the captured PGID (with a 2-second grace between them). This
+///   reaches workloads that have been reparented to the remote's init
+///   (docker daemon's containerd-shim, sshd, …) and would otherwise
+///   survive the death of our host-side wrapper.
+///
+/// If the sentinel never arrives (extremely fast cancellation, or a
+/// target without `setsid`/base64), the helper falls back to host-tree
+/// reaping only — the remote process *may* leak in that narrow window.
+pub async fn run_with_shim(
+    binary: &CliBinary,
+    args: &[&str],
+    env: Option<&HashMap<String, String>>,
+    cancel: &CancellationToken,
+    on_chunk: Option<Arc<dyn ChunkSink>>,
+    killer: Arc<dyn RemoteKiller>,
+) -> Result<CliOutput> {
+    let mut cmd = Command::new(binary.command_name());
+    cmd.args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    if let Some(env_vars) = env {
+        for (k, v) in env_vars {
+            cmd.env(k, v);
+        }
+    }
+
+    let mut child = cmd.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            binary.not_found_error()
+        } else {
+            Error::Io(e)
+        }
+    })?;
+
+    let stdout = child.stdout.take().expect("stdout was piped");
+    let stderr = child.stderr.take().expect("stderr was piped");
+
+    // Shared captured PGID. Filled in by the stderr reader as soon as
+    // the shim's sentinel line arrives; consumed by the cancel branch.
+    let pgid: Arc<std::sync::Mutex<Option<i32>>> = Arc::new(std::sync::Mutex::new(None));
+
+    // stdout: no sentinel to scrub (the shim writes it to stderr).
+    let stdout_task = tokio::spawn(drain_stream(
+        stdout,
+        OutputStream::Stdout,
+        on_chunk.clone(),
+    ));
+    // stderr: filter the sentinel line, forward everything else.
+    let stderr_task = tokio::spawn(drain_stream_with_sentinel(
+        stderr,
+        OutputStream::Stderr,
+        on_chunk.clone(),
+        pgid.clone(),
+    ));
+
+    let status = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            tracing::warn!(
+                bin = binary.command_name(),
+                "cancellation received; killing remote process group then host wrapper"
+            );
+
+            let captured = *pgid.lock().expect("pgid lock");
+            match captured {
+                Some(pgid_val) => {
+                    // Remote kill first: if we kill the host wrapper
+                    // first, the transport to the target closes and
+                    // the remote work keeps running.
+                    killer.kill_pgid(pgid_val, "TERM").await;
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    killer.kill_pgid(pgid_val, "KILL").await;
+                }
+                None => {
+                    tracing::warn!(
+                        bin = binary.command_name(),
+                        "no remote PGID captured; relying on host reap (may leak)"
+                    );
+                }
+            }
+
+            // Host-side reap of the wrapper and any host descendants
+            // we *can* see. For SSH-based backends this catches the
+            // local SSH client process.
+            if let Some(root_pid) = child.id() {
+                crate::process_tree::reap(root_pid, std::time::Duration::from_secs(2)).await;
+            }
+
+            let _ = tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                child.wait(),
+            )
+            .await;
+            let _ = stdout_task.await;
+            let _ = stderr_task.await;
+            return Err(Error::Cancelled);
+        }
+        status = child.wait() => status?,
+    };
+
+    let stdout_buf = stdout_task.await.unwrap_or_default();
+    let stderr_buf = stderr_task.await.unwrap_or_default();
+
+    Ok(CliOutput {
+        exit_code: status.code().unwrap_or(-1),
+        stdout: stdout_buf,
+        stderr: stderr_buf,
+        json: None,
+    })
+}
+
+#[cfg(test)]
+mod shim_runner_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Mutex;
+
+    /// Records every `kill_pgid` invocation so tests can assert on
+    /// the order and arguments.
+    struct RecordingKiller {
+        calls: Mutex<Vec<(i32, String)>>,
+    }
+
+    #[async_trait::async_trait]
+    impl RemoteKiller for RecordingKiller {
+        async fn kill_pgid(&self, pgid: i32, signal: &str) {
+            self.calls.lock().unwrap().push((pgid, signal.to_string()));
+        }
+    }
+
+    /// Sink that just counts received chunks.
+    struct CountingSink {
+        stdout_lines: AtomicU64,
+        stderr_lines: AtomicU64,
+    }
+    #[async_trait::async_trait]
+    impl ChunkSink for CountingSink {
+        async fn on_chunk(&self, chunk: OutputChunk) {
+            match chunk.stream {
+                OutputStream::Stdout => {
+                    self.stdout_lines.fetch_add(1, Ordering::Relaxed);
+                }
+                OutputStream::Stderr => {
+                    self.stderr_lines.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+
+    /// Create a `devpod` shim script in `dir` that ignores all args
+    /// except the value after `--command` and runs that under `sh -c`.
+    /// This lets us drive `run_with_shim` end-to-end without a real
+    /// DevPod install — `binary.command_name()` is `devpod`, and our
+    /// shim picks it up from `PATH`.
+    fn install_devpod_shim(dir: &std::path::Path) -> std::path::PathBuf {
+        let script = dir.join("devpod");
+        // The fake devpod: parse out `--command <cmd>` and exec it
+        // via `sh -c`. Everything else (workspace name, --user, etc.)
+        // is discarded — we only care that the shim's body runs.
+        let body = r#"#!/bin/sh
+cmd=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --command)
+      shift
+      cmd="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+exec sh -c "$cmd"
+"#;
+        std::fs::write(&script, body).expect("write shim");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&script).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&script, perms).unwrap();
+        }
+        script
+    }
+
+    /// End-to-end: shim wraps a sleep, runner captures PGID from
+    /// stderr, cancellation triggers RemoteKiller in the right order
+    /// (TERM then KILL with a 2s gap), and the call returns
+    /// Error::Cancelled.
+    ///
+    /// This exercises the full `run_with_shim` flow without docker
+    /// or any real backend — the `RemoteKiller` is a recording fake
+    /// and the "remote" is just a local shell invoked by a stub
+    /// `devpod` shim on PATH.
+    #[tokio::test]
+    async fn run_with_shim_invokes_killer_in_order_on_cancel() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        install_devpod_shim(tmp.path());
+        let new_path = format!(
+            "{}:{}",
+            tmp.path().display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        // Safe because tests in this module are single-threaded by
+        // tokio::test's default runtime; if we move to multi_thread
+        // we'd need a process-wide PATH lock.
+        // SAFETY: see comment above.
+        unsafe {
+            std::env::set_var("PATH", &new_path);
+        }
+
+        let killer = Arc::new(RecordingKiller {
+            calls: Mutex::new(Vec::new()),
+        });
+        let sink = Arc::new(CountingSink {
+            stdout_lines: AtomicU64::new(0),
+            stderr_lines: AtomicU64::new(0),
+        });
+        let cancel = CancellationToken::new();
+
+        // The "user command" — backgrounded sleeps + wait. The shim
+        // wraps this so the runner sees the sentinel on stderr.
+        let user_cmd = "sleep 30 & sleep 30 & wait";
+        let wrapped = crate::exec_shim::wrap_self_contained(user_cmd);
+
+        // Spawn the call and cancel it shortly after.
+        let killer_for_spawn: Arc<dyn RemoteKiller> = killer.clone();
+        let sink_for_spawn: Arc<dyn ChunkSink> = sink.clone();
+        let cancel_for_spawn = cancel.clone();
+        let handle = tokio::spawn(async move {
+            let args = vec!["ssh", "fake-ws", "--command", wrapped.as_str()];
+            run_with_shim(
+                &CliBinary::DevPod,
+                &args,
+                None,
+                &cancel_for_spawn,
+                Some(sink_for_spawn),
+                killer_for_spawn,
+            )
+            .await
+        });
+
+        // Give the shim time to emit the sentinel.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        cancel.cancel();
+
+        let result = handle.await.expect("join");
+        match result {
+            Err(Error::Cancelled) => { /* expected */ }
+            other => panic!("expected Error::Cancelled, got {:?}", other),
+        }
+
+        // Killer should have been called once with TERM, then once
+        // with KILL, both targeting the same PGID (>0). The 2s gap
+        // is checked separately below.
+        let calls = killer.calls.lock().unwrap().clone();
+        assert_eq!(calls.len(), 2, "expected exactly 2 kill calls, got {calls:?}");
+        let (pgid1, sig1) = &calls[0];
+        let (pgid2, sig2) = &calls[1];
+        assert_eq!(sig1, "TERM");
+        assert_eq!(sig2, "KILL");
+        assert!(*pgid1 > 0, "captured PGID should be positive, got {pgid1}");
+        assert_eq!(pgid1, pgid2, "both signals should target the same PGID");
+
+        // Sentinel must NOT have leaked into the sink's stderr count
+        // — if it had, sink.stderr_lines would include at least the
+        // sentinel line for every chunk. Concretely, the user_cmd
+        // produces no stderr at all, so stderr_lines should be 0.
+        assert_eq!(
+            sink.stderr_lines.load(Ordering::Relaxed),
+            0,
+            "sentinel should be scrubbed from stderr forwarded to sink"
+        );
+    }
+}

--- a/crates/devcontainer-mcp-core/src/codespaces.rs
+++ b/crates/devcontainer-mcp-core/src/codespaces.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use crate::cli::{
-    run_cli_with_env, run_with_shim, ChunkSink, CliBinary, CliOutput, RemoteKiller,
+    run_cli_streaming, run_cli_with_env, run_with_shim, ChunkSink, CliBinary, CliOutput,
+    RemoteKiller,
 };
 use crate::error::Result;
 
@@ -59,6 +60,52 @@ pub async fn create(
         args.push(t);
     }
     run_gh_cs(&args, false, Some(env)).await
+}
+
+/// `gh codespace create` — cancellable, streaming variant.
+///
+/// Codespace creation takes 3–5 minutes (image pull, devcontainer
+/// build, postCreate, …). Streams `gh codespace create` output as
+/// progress notifications and honors cancellation — when the client
+/// times out we kill the host `gh` process. Note: this only reaps
+/// the host wrapper; if the GitHub API has already started
+/// provisioning the codespace remotely, the codespace itself will
+/// continue to come up and bill until the caller explicitly deletes
+/// it via `codespaces_delete`. The wire-level cancel is the most we
+/// can do — there's no `gh codespace cancel-create` API.
+pub async fn create_streaming(
+    env: &HashMap<String, String>,
+    repo: &str,
+    branch: Option<&str>,
+    machine: Option<&str>,
+    devcontainer_path: Option<&str>,
+    display_name: Option<&str>,
+    idle_timeout: Option<&str>,
+    cancel: &CancellationToken,
+    on_chunk: Option<Arc<dyn ChunkSink>>,
+) -> Result<CliOutput> {
+    let mut args = vec!["codespace", "create", "--repo", repo];
+    if let Some(b) = branch {
+        args.push("--branch");
+        args.push(b);
+    }
+    if let Some(m) = machine {
+        args.push("--machine");
+        args.push(m);
+    }
+    if let Some(d) = devcontainer_path {
+        args.push("--devcontainer-path");
+        args.push(d);
+    }
+    if let Some(n) = display_name {
+        args.push("--display-name");
+        args.push(n);
+    }
+    if let Some(t) = idle_timeout {
+        args.push("--idle-timeout");
+        args.push(t);
+    }
+    run_cli_streaming(&CliBinary::Gh, &args, false, Some(env), cancel, on_chunk).await
 }
 
 /// `gh codespace list` — list codespaces.

--- a/crates/devcontainer-mcp-core/src/codespaces.rs
+++ b/crates/devcontainer-mcp-core/src/codespaces.rs
@@ -1,6 +1,10 @@
 use std::collections::HashMap;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
 
-use crate::cli::{run_cli_with_env, CliBinary, CliOutput};
+use crate::cli::{
+    run_cli_with_env, run_with_shim, ChunkSink, CliBinary, CliOutput, RemoteKiller,
+};
 use crate::error::Result;
 
 const LIST_FIELDS: &str =
@@ -75,6 +79,64 @@ pub async fn ssh_exec(
 ) -> Result<CliOutput> {
     let args = vec!["ssh", "-c", codespace, "--", command];
     run_gh_cs(&args, false, Some(env)).await
+}
+
+/// `gh codespace ssh` — cancellable, streaming variant.
+///
+/// Same model as the DevPod backend: the user's command is wrapped
+/// with [`crate::exec_shim::wrap_self_contained`] (the codespace
+/// transport has no `--remote-env`), the captured PGID is stripped
+/// from stderr, and on cancel a second `gh codespace ssh` delivers
+/// `kill -TERM -<pgid>` then `kill -KILL -<pgid>` against the same
+/// codespace.
+pub async fn ssh_exec_streaming(
+    env: &HashMap<String, String>,
+    codespace: &str,
+    command: &str,
+    cancel: &CancellationToken,
+    on_chunk: Option<Arc<dyn ChunkSink>>,
+) -> Result<CliOutput> {
+    let wrapped = crate::exec_shim::wrap_self_contained(command);
+    // `gh codespace ssh -c <cs> -- <cmd>` — the `--` separates gh's
+    // own args from the remote command, so the wrapped shim lands as
+    // the single remote argument.
+    let full_args: Vec<&str> = vec!["codespace", "ssh", "-c", codespace, "--", &wrapped];
+
+    let killer: Arc<dyn RemoteKiller> = Arc::new(CodespaceKiller {
+        env: env.clone(),
+        codespace: codespace.to_string(),
+    });
+
+    run_with_shim(
+        &CliBinary::Gh,
+        &full_args,
+        Some(env),
+        cancel,
+        on_chunk,
+        killer,
+    )
+    .await
+}
+
+/// Delivers `kill -<sig> -<pgid>` inside a Codespace by spawning a
+/// fresh short-lived `gh codespace ssh`. Same trade-off as the DevPod
+/// backend — every kill is its own SSH session, slow but reliable.
+struct CodespaceKiller {
+    env: HashMap<String, String>,
+    codespace: String,
+}
+
+#[async_trait::async_trait]
+impl RemoteKiller for CodespaceKiller {
+    async fn kill_pgid(&self, pgid: i32, signal: &str) {
+        let cmd = format!("kill -{signal} -{pgid} 2>/dev/null || true");
+        let args = vec!["codespace", "ssh", "-c", &self.codespace, "--", &cmd];
+        if let Err(e) =
+            run_cli_with_env(&CliBinary::Gh, &args, false, Some(&self.env)).await
+        {
+            tracing::debug!(%e, pgid, signal, "gh codespace ssh kill failed");
+        }
+    }
 }
 
 /// `gh codespace stop` — stop a running codespace.

--- a/crates/devcontainer-mcp-core/src/codespaces.rs
+++ b/crates/devcontainer-mcp-core/src/codespaces.rs
@@ -73,6 +73,12 @@ pub async fn create(
 /// continue to come up and bill until the caller explicitly deletes
 /// it via `codespaces_delete`. The wire-level cancel is the most we
 /// can do — there's no `gh codespace cancel-create` API.
+//
+// `clippy::too_many_arguments` — each parameter mirrors a distinct
+// `gh codespace create` flag, and the non-streaming sibling
+// [`create`] has the same shape with one fewer pair. Bundling into
+// a struct would obscure the call site for no real readability win.
+#[allow(clippy::too_many_arguments)]
 pub async fn create_streaming(
     env: &HashMap<String, String>,
     repo: &str,

--- a/crates/devcontainer-mcp-core/src/devcontainer.rs
+++ b/crates/devcontainer-mcp-core/src/devcontainer.rs
@@ -1,4 +1,6 @@
-use crate::cli::{run_cli, run_with_shim, ChunkSink, CliBinary, CliOutput, RemoteKiller};
+use crate::cli::{
+    run_cli, run_cli_streaming, run_with_shim, ChunkSink, CliBinary, CliOutput, RemoteKiller,
+};
 use crate::docker;
 use crate::error::Result;
 use std::sync::Arc;
@@ -26,6 +28,38 @@ pub async fn up(
     }
     args.extend_from_slice(extra_args);
     run_devcontainer(&args, true).await
+}
+
+/// `devcontainer up` — cancellable, streaming variant.
+///
+/// `devcontainer up` does a docker build + container create + the
+/// devcontainer lifecycle commands (postCreate, postStart, etc.) all
+/// in one invocation. That can easily take several minutes on a
+/// cold image. Same rationale as `crate::devpod::up_streaming`:
+/// cancellation prevents leaked partial-up containers, and progress
+/// streaming keeps client transports warm.
+pub async fn up_streaming(
+    workspace_folder: &str,
+    config: Option<&str>,
+    extra_args: &[&str],
+    cancel: &CancellationToken,
+    on_chunk: Option<Arc<dyn ChunkSink>>,
+) -> Result<CliOutput> {
+    let mut args = vec!["up", "--workspace-folder", workspace_folder];
+    if let Some(c) = config {
+        args.push("--config");
+        args.push(c);
+    }
+    args.extend_from_slice(extra_args);
+    run_cli_streaming(
+        &CliBinary::Devcontainer,
+        &args,
+        true,
+        None,
+        cancel,
+        on_chunk,
+    )
+    .await
 }
 
 /// `devcontainer exec` — execute a command in a running dev container.
@@ -183,6 +217,27 @@ pub async fn build(workspace_folder: &str, extra_args: &[&str]) -> Result<CliOut
     let mut args = vec!["build", "--workspace-folder", workspace_folder];
     args.extend_from_slice(extra_args);
     run_devcontainer(&args, true).await
+}
+
+/// `devcontainer build` — cancellable, streaming variant. See
+/// [`up_streaming`].
+pub async fn build_streaming(
+    workspace_folder: &str,
+    extra_args: &[&str],
+    cancel: &CancellationToken,
+    on_chunk: Option<Arc<dyn ChunkSink>>,
+) -> Result<CliOutput> {
+    let mut args = vec!["build", "--workspace-folder", workspace_folder];
+    args.extend_from_slice(extra_args);
+    run_cli_streaming(
+        &CliBinary::Devcontainer,
+        &args,
+        true,
+        None,
+        cancel,
+        on_chunk,
+    )
+    .await
 }
 
 /// `devcontainer read-configuration` — read devcontainer config as JSON.

--- a/crates/devcontainer-mcp-core/src/devcontainer.rs
+++ b/crates/devcontainer-mcp-core/src/devcontainer.rs
@@ -1,6 +1,8 @@
-use crate::cli::{run_cli, CliBinary, CliOutput};
+use crate::cli::{run_cli, ChunkSink, CliBinary, CliOutput};
 use crate::docker;
 use crate::error::Result;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
 
 /// Run a `devcontainer` CLI command.
 async fn run_devcontainer(args: &[&str], parse_json: bool) -> Result<CliOutput> {
@@ -35,6 +37,265 @@ pub async fn exec(
     let mut args = vec!["exec", "--workspace-folder", workspace_folder, command];
     args.extend_from_slice(command_args);
     run_devcontainer(&args, false).await
+}
+
+/// `devcontainer exec` — cancellable, streaming variant.
+///
+/// `cancel` is honored at any point during the child's lifetime; if it
+/// fires, every descendant inside the container is reaped via a docker
+/// exec-side `kill -- -<pgid>` against the process group the shim
+/// established. `on_chunk`, if supplied, receives every line of
+/// stdout/stderr as the child emits it — typically wired to an MCP
+/// progress notification on the server side.
+///
+/// This function differs from the generic [`crate::cli::run_cli_streaming`]
+/// in one important way: container descendants are not in the host PID
+/// namespace lineage of `devcontainer exec` (the docker daemon
+/// reparents them under containerd-shim), so a `/proc` walk on the host
+/// would miss them. We install a tiny `setsid` + sentinel shim around
+/// the user command and use the captured PGID to reap them on cancel.
+pub async fn exec_streaming(
+    workspace_folder: &str,
+    command: &str,
+    command_args: &[&str],
+    cancel: &CancellationToken,
+    on_chunk: Option<Arc<dyn ChunkSink>>,
+) -> Result<CliOutput> {
+    use crate::cli::{OutputChunk, OutputStream};
+    use std::process::Stdio;
+    use std::sync::Mutex;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::process::Command;
+
+    // Build the user-side command string. The MCP handler invokes us
+    // as `("sh", &["-c", &full_cmd])`, which is the fast path: peel
+    // off the `-c` arg so the shim wraps the body directly instead of
+    // nesting an extra shell. For any other shape, fall back to a
+    // best-effort shell-quoted concatenation.
+    let user_cmd: String = if command == "sh" && command_args.len() == 2 && command_args[0] == "-c"
+    {
+        command_args[1].to_string()
+    } else {
+        let mut parts = vec![crate::file_ops::shell_quote(command)];
+        for a in command_args {
+            parts.push(crate::file_ops::shell_quote(a));
+        }
+        parts.join(" ")
+    };
+
+    let wrapped = crate::exec_shim::wrap();
+    // The user command is passed to the shim via an env var so it
+    // doesn't need to be quoted into a nested `sh -c '...'`. We use
+    // `--remote-env NAME=VALUE` so the devcontainer CLI propagates
+    // it inside the container.
+    let remote_env_arg = format!("{}={}", crate::exec_shim::USER_CMD_ENV, user_cmd);
+
+    // Spawn `devcontainer exec --workspace-folder <ws> --remote-env … sh -c <wrapped>`.
+    let mut cmd = Command::new(crate::cli::CliBinary::Devcontainer.command_name());
+    cmd.args([
+        "exec",
+        "--workspace-folder",
+        workspace_folder,
+        "--remote-env",
+        &remote_env_arg,
+        "sh",
+        "-c",
+        &wrapped,
+    ])
+    .stdin(Stdio::null())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .kill_on_drop(true);
+
+    let mut child = cmd.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            crate::error::Error::DevcontainerCliNotFound
+        } else {
+            crate::error::Error::Io(e)
+        }
+    })?;
+
+    let stdout = child.stdout.take().expect("stdout piped");
+    let stderr = child.stderr.take().expect("stderr piped");
+
+    // Shared captured PGID. The stderr reader fills this in as soon as
+    // the shim's sentinel line arrives; the cancel branch reads it.
+    let pgid: Arc<Mutex<Option<i32>>> = Arc::new(Mutex::new(None));
+
+    // stdout: forward verbatim (no sentinel to scrub).
+    let stdout_task = {
+        let sink = on_chunk.clone();
+        tokio::spawn(async move {
+            let mut buf = String::new();
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if !buf.is_empty() {
+                    buf.push('\n');
+                }
+                buf.push_str(&line);
+                if let Some(s) = sink.as_ref() {
+                    s.on_chunk(OutputChunk {
+                        stream: OutputStream::Stdout,
+                        line,
+                    })
+                    .await;
+                }
+            }
+            if !buf.is_empty() {
+                buf.push('\n');
+            }
+            buf
+        })
+    };
+
+    // stderr: scrub the sentinel line, otherwise forward verbatim.
+    let stderr_task = {
+        let sink = on_chunk.clone();
+        let pgid = pgid.clone();
+        tokio::spawn(async move {
+            let mut buf = String::new();
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if let Some(found) = crate::exec_shim::try_parse_sentinel(&line) {
+                    *pgid.lock().expect("pgid lock") = Some(found);
+                    tracing::debug!(pgid = found, "captured in-container PGID");
+                    continue; // suppress sentinel from user-visible stderr
+                }
+                if !buf.is_empty() {
+                    buf.push('\n');
+                }
+                buf.push_str(&line);
+                if let Some(s) = sink.as_ref() {
+                    s.on_chunk(OutputChunk {
+                        stream: OutputStream::Stderr,
+                        line,
+                    })
+                    .await;
+                }
+            }
+            if !buf.is_empty() {
+                buf.push('\n');
+            }
+            buf
+        })
+    };
+
+    let status = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            tracing::warn!("devcontainer exec: cancellation received");
+
+            // Kill the in-container process group first, then the host
+            // wrapper. Order matters: if we kill the host wrapper first,
+            // docker exec closes its stdio and we lose the channel —
+            // but the in-container processes keep running anyway.
+            let captured = *pgid.lock().expect("pgid lock");
+            match captured {
+                Some(pgid) => {
+                    if let Err(e) = kill_in_container_pgid(workspace_folder, pgid).await {
+                        tracing::warn!(%e, "failed to kill in-container PGID");
+                    }
+                }
+                None => {
+                    // Sentinel never arrived — either the shim hasn't
+                    // emitted yet (very fast cancel) or `setsid` isn't
+                    // available and the fallback path didn't emit
+                    // before we cancelled. Either way, host-side reap
+                    // is our only lever.
+                    tracing::warn!(
+                        "no in-container PGID captured; relying on host reap (may leak)"
+                    );
+                }
+            }
+
+            // Now bring down the host wrapper and any of its host-side
+            // descendants we *can* see.
+            if let Some(root_pid) = child.id() {
+                crate::process_tree::reap(root_pid, std::time::Duration::from_secs(2)).await;
+            }
+
+            let _ = tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                child.wait(),
+            )
+            .await;
+            let _ = stdout_task.await;
+            let _ = stderr_task.await;
+            return Err(crate::error::Error::Cancelled);
+        }
+        status = child.wait() => status?,
+    };
+
+    let stdout_buf = stdout_task.await.unwrap_or_default();
+    let stderr_buf = stderr_task.await.unwrap_or_default();
+
+    Ok(CliOutput {
+        exit_code: status.code().unwrap_or(-1),
+        stdout: stdout_buf,
+        stderr: stderr_buf,
+        json: None,
+    })
+}
+
+/// Send SIGTERM (then SIGKILL after a 2s grace) to the in-container
+/// process group `pgid`. Uses bollard's exec API so it works against the
+/// docker daemon without shelling out.
+async fn kill_in_container_pgid(workspace_folder: &str, pgid: i32) -> Result<()> {
+    use bollard::exec::{CreateExecOptions, StartExecOptions};
+
+    let client = docker::connect()?;
+    let container = docker::find_container_by_local_folder(&client, workspace_folder)
+        .await?
+        .ok_or_else(|| {
+            crate::error::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("No devcontainer found for workspace: {workspace_folder}"),
+            ))
+        })?;
+
+    // `kill -<sig> -<pgid>` signals every process in the group. We
+    // deliberately omit the POSIX `--` argument separator because
+    // BusyBox/dash `kill` (common in slim container images) rejects
+    // it as "Illegal number". The form `kill -TERM -N` is accepted
+    // by every shell `kill` we care about.
+    let run = |sig: &'static str| -> futures_util::future::BoxFuture<'static, ()> {
+        let client = client.clone();
+        let container_id = container.id.clone();
+        let cmd = format!("kill -{sig} -{pgid} 2>/dev/null || true");
+        Box::pin(async move {
+            let create = CreateExecOptions {
+                cmd: Some(vec!["sh".to_string(), "-c".to_string(), cmd]),
+                attach_stdout: Some(false),
+                attach_stderr: Some(false),
+                ..Default::default()
+            };
+            match client.create_exec(&container_id, create).await {
+                Ok(res) => {
+                    // `detach: true` makes start_exec return as soon as
+                    // the docker daemon has spawned the kill — we don't
+                    // need to stream its (empty) output. The signal will
+                    // be delivered before we proceed to the next step.
+                    let opts = StartExecOptions {
+                        detach: true,
+                        ..Default::default()
+                    };
+                    if let Err(e) = client.start_exec(&res.id, Some(opts)).await {
+                        tracing::debug!(%e, "start_exec for in-container kill failed");
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!(%e, "create_exec for in-container kill failed");
+                }
+            }
+        })
+    };
+
+    tracing::debug!(pgid, "in-container SIGTERM -<pgid>");
+    run("TERM").await;
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    tracing::debug!(pgid, "in-container SIGKILL -<pgid>");
+    run("KILL").await;
+    Ok(())
 }
 
 /// `devcontainer build` — build a dev container image.

--- a/crates/devcontainer-mcp-core/src/devcontainer.rs
+++ b/crates/devcontainer-mcp-core/src/devcontainer.rs
@@ -1,4 +1,4 @@
-use crate::cli::{run_cli, ChunkSink, CliBinary, CliOutput};
+use crate::cli::{run_cli, run_with_shim, ChunkSink, CliBinary, CliOutput, RemoteKiller};
 use crate::docker;
 use crate::error::Result;
 use std::sync::Arc;
@@ -42,18 +42,18 @@ pub async fn exec(
 /// `devcontainer exec` — cancellable, streaming variant.
 ///
 /// `cancel` is honored at any point during the child's lifetime; if it
-/// fires, every descendant inside the container is reaped via a docker
-/// exec-side `kill -- -<pgid>` against the process group the shim
-/// established. `on_chunk`, if supplied, receives every line of
-/// stdout/stderr as the child emits it — typically wired to an MCP
-/// progress notification on the server side.
+/// fires, every descendant inside the container is reaped via a
+/// bollard `create_exec` + `start_exec` of `kill -<sig> -<pgid>`
+/// against the process group the shim established. `on_chunk`, if
+/// supplied, receives every line of stdout/stderr as the child emits
+/// it — typically wired to an MCP progress notification on the server
+/// side.
 ///
-/// This function differs from the generic [`crate::cli::run_cli_streaming`]
-/// in one important way: container descendants are not in the host PID
-/// namespace lineage of `devcontainer exec` (the docker daemon
-/// reparents them under containerd-shim), so a `/proc` walk on the host
-/// would miss them. We install a tiny `setsid` + sentinel shim around
-/// the user command and use the captured PGID to reap them on cancel.
+/// Container descendants are not in the host PID namespace lineage of
+/// `devcontainer exec` (the docker daemon reparents them under
+/// containerd-shim), so a `/proc` walk on the host would miss them.
+/// We install a tiny `setsid` + sentinel shim around the user command
+/// and use the captured PGID to reap them on cancel.
 pub async fn exec_streaming(
     workspace_folder: &str,
     command: &str,
@@ -61,12 +61,6 @@ pub async fn exec_streaming(
     cancel: &CancellationToken,
     on_chunk: Option<Arc<dyn ChunkSink>>,
 ) -> Result<CliOutput> {
-    use crate::cli::{OutputChunk, OutputStream};
-    use std::process::Stdio;
-    use std::sync::Mutex;
-    use tokio::io::{AsyncBufReadExt, BufReader};
-    use tokio::process::Command;
-
     // Build the user-side command string. The MCP handler invokes us
     // as `("sh", &["-c", &full_cmd])`, which is the fast path: peel
     // off the `-c` arg so the shim wraps the body directly instead of
@@ -87,12 +81,12 @@ pub async fn exec_streaming(
     // The user command is passed to the shim via an env var so it
     // doesn't need to be quoted into a nested `sh -c '...'`. We use
     // `--remote-env NAME=VALUE` so the devcontainer CLI propagates
-    // it inside the container.
+    // it inside the container. This is the env-var path; the
+    // self-contained `wrap_self_contained` variant is for backends
+    // (DevPod, Codespaces) that can't pass remote env vars.
     let remote_env_arg = format!("{}={}", crate::exec_shim::USER_CMD_ENV, user_cmd);
 
-    // Spawn `devcontainer exec --workspace-folder <ws> --remote-env … sh -c <wrapped>`.
-    let mut cmd = Command::new(crate::cli::CliBinary::Devcontainer.command_name());
-    cmd.args([
+    let args: [&str; 7] = [
         "exec",
         "--workspace-folder",
         workspace_folder,
@@ -100,202 +94,88 @@ pub async fn exec_streaming(
         &remote_env_arg,
         "sh",
         "-c",
-        &wrapped,
-    ])
-    .stdin(Stdio::null())
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped())
-    .kill_on_drop(true);
+    ];
+    // run_with_shim takes a slice of &str; build a Vec to add the wrapped tail.
+    let mut all_args: Vec<&str> = args.to_vec();
+    all_args.push(&wrapped);
 
-    let mut child = cmd.spawn().map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound {
-            crate::error::Error::DevcontainerCliNotFound
-        } else {
-            crate::error::Error::Io(e)
-        }
-    })?;
+    let killer: Arc<dyn RemoteKiller> = Arc::new(DevcontainerKiller {
+        workspace_folder: workspace_folder.to_string(),
+    });
 
-    let stdout = child.stdout.take().expect("stdout piped");
-    let stderr = child.stderr.take().expect("stderr piped");
-
-    // Shared captured PGID. The stderr reader fills this in as soon as
-    // the shim's sentinel line arrives; the cancel branch reads it.
-    let pgid: Arc<Mutex<Option<i32>>> = Arc::new(Mutex::new(None));
-
-    // stdout: forward verbatim (no sentinel to scrub).
-    let stdout_task = {
-        let sink = on_chunk.clone();
-        tokio::spawn(async move {
-            let mut buf = String::new();
-            let mut lines = BufReader::new(stdout).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                if !buf.is_empty() {
-                    buf.push('\n');
-                }
-                buf.push_str(&line);
-                if let Some(s) = sink.as_ref() {
-                    s.on_chunk(OutputChunk {
-                        stream: OutputStream::Stdout,
-                        line,
-                    })
-                    .await;
-                }
-            }
-            if !buf.is_empty() {
-                buf.push('\n');
-            }
-            buf
-        })
-    };
-
-    // stderr: scrub the sentinel line, otherwise forward verbatim.
-    let stderr_task = {
-        let sink = on_chunk.clone();
-        let pgid = pgid.clone();
-        tokio::spawn(async move {
-            let mut buf = String::new();
-            let mut lines = BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                if let Some(found) = crate::exec_shim::try_parse_sentinel(&line) {
-                    *pgid.lock().expect("pgid lock") = Some(found);
-                    tracing::debug!(pgid = found, "captured in-container PGID");
-                    continue; // suppress sentinel from user-visible stderr
-                }
-                if !buf.is_empty() {
-                    buf.push('\n');
-                }
-                buf.push_str(&line);
-                if let Some(s) = sink.as_ref() {
-                    s.on_chunk(OutputChunk {
-                        stream: OutputStream::Stderr,
-                        line,
-                    })
-                    .await;
-                }
-            }
-            if !buf.is_empty() {
-                buf.push('\n');
-            }
-            buf
-        })
-    };
-
-    let status = tokio::select! {
-        biased;
-        _ = cancel.cancelled() => {
-            tracing::warn!("devcontainer exec: cancellation received");
-
-            // Kill the in-container process group first, then the host
-            // wrapper. Order matters: if we kill the host wrapper first,
-            // docker exec closes its stdio and we lose the channel —
-            // but the in-container processes keep running anyway.
-            let captured = *pgid.lock().expect("pgid lock");
-            match captured {
-                Some(pgid) => {
-                    if let Err(e) = kill_in_container_pgid(workspace_folder, pgid).await {
-                        tracing::warn!(%e, "failed to kill in-container PGID");
-                    }
-                }
-                None => {
-                    // Sentinel never arrived — either the shim hasn't
-                    // emitted yet (very fast cancel) or `setsid` isn't
-                    // available and the fallback path didn't emit
-                    // before we cancelled. Either way, host-side reap
-                    // is our only lever.
-                    tracing::warn!(
-                        "no in-container PGID captured; relying on host reap (may leak)"
-                    );
-                }
-            }
-
-            // Now bring down the host wrapper and any of its host-side
-            // descendants we *can* see.
-            if let Some(root_pid) = child.id() {
-                crate::process_tree::reap(root_pid, std::time::Duration::from_secs(2)).await;
-            }
-
-            let _ = tokio::time::timeout(
-                std::time::Duration::from_secs(1),
-                child.wait(),
-            )
-            .await;
-            let _ = stdout_task.await;
-            let _ = stderr_task.await;
-            return Err(crate::error::Error::Cancelled);
-        }
-        status = child.wait() => status?,
-    };
-
-    let stdout_buf = stdout_task.await.unwrap_or_default();
-    let stderr_buf = stderr_task.await.unwrap_or_default();
-
-    Ok(CliOutput {
-        exit_code: status.code().unwrap_or(-1),
-        stdout: stdout_buf,
-        stderr: stderr_buf,
-        json: None,
-    })
+    run_with_shim(
+        &CliBinary::Devcontainer,
+        &all_args,
+        None,
+        cancel,
+        on_chunk,
+        killer,
+    )
+    .await
 }
 
-/// Send SIGTERM (then SIGKILL after a 2s grace) to the in-container
-/// process group `pgid`. Uses bollard's exec API so it works against the
-/// docker daemon without shelling out.
-async fn kill_in_container_pgid(workspace_folder: &str, pgid: i32) -> Result<()> {
-    use bollard::exec::{CreateExecOptions, StartExecOptions};
+/// Delivers `kill -<sig> -<pgid>` inside the devcontainer associated
+/// with a workspace folder, using bollard's exec API.
+struct DevcontainerKiller {
+    workspace_folder: String,
+}
 
-    let client = docker::connect()?;
-    let container = docker::find_container_by_local_folder(&client, workspace_folder)
-        .await?
-        .ok_or_else(|| {
-            crate::error::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("No devcontainer found for workspace: {workspace_folder}"),
-            ))
-        })?;
+#[async_trait::async_trait]
+impl RemoteKiller for DevcontainerKiller {
+    async fn kill_pgid(&self, pgid: i32, signal: &str) {
+        use bollard::exec::{CreateExecOptions, StartExecOptions};
 
-    // `kill -<sig> -<pgid>` signals every process in the group. We
-    // deliberately omit the POSIX `--` argument separator because
-    // BusyBox/dash `kill` (common in slim container images) rejects
-    // it as "Illegal number". The form `kill -TERM -N` is accepted
-    // by every shell `kill` we care about.
-    let run = |sig: &'static str| -> futures_util::future::BoxFuture<'static, ()> {
-        let client = client.clone();
-        let container_id = container.id.clone();
-        let cmd = format!("kill -{sig} -{pgid} 2>/dev/null || true");
-        Box::pin(async move {
-            let create = CreateExecOptions {
-                cmd: Some(vec!["sh".to_string(), "-c".to_string(), cmd]),
-                attach_stdout: Some(false),
-                attach_stderr: Some(false),
-                ..Default::default()
-            };
-            match client.create_exec(&container_id, create).await {
-                Ok(res) => {
-                    // `detach: true` makes start_exec return as soon as
-                    // the docker daemon has spawned the kill — we don't
-                    // need to stream its (empty) output. The signal will
-                    // be delivered before we proceed to the next step.
-                    let opts = StartExecOptions {
-                        detach: true,
-                        ..Default::default()
-                    };
-                    if let Err(e) = client.start_exec(&res.id, Some(opts)).await {
-                        tracing::debug!(%e, "start_exec for in-container kill failed");
-                    }
-                }
-                Err(e) => {
-                    tracing::debug!(%e, "create_exec for in-container kill failed");
-                }
+        let client = match docker::connect() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(%e, "failed to connect to docker for in-container kill");
+                return;
             }
-        })
-    };
+        };
+        let container = match docker::find_container_by_local_folder(&client, &self.workspace_folder).await {
+            Ok(Some(c)) => c,
+            Ok(None) => {
+                tracing::warn!(
+                    workspace = %self.workspace_folder,
+                    "no devcontainer found for in-container kill"
+                );
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(%e, "container lookup failed during in-container kill");
+                return;
+            }
+        };
 
-    tracing::debug!(pgid, "in-container SIGTERM -<pgid>");
-    run("TERM").await;
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-    tracing::debug!(pgid, "in-container SIGKILL -<pgid>");
-    run("KILL").await;
-    Ok(())
+        // `kill -<sig> -<pgid>` signals every process in the group.
+        // The POSIX `--` argument separator is deliberately omitted
+        // because BusyBox/dash `kill` (common in slim container
+        // images) rejects it as "Illegal number".
+        let cmd = format!("kill -{signal} -{pgid} 2>/dev/null || true");
+        let create = CreateExecOptions {
+            cmd: Some(vec!["sh".to_string(), "-c".to_string(), cmd]),
+            attach_stdout: Some(false),
+            attach_stderr: Some(false),
+            ..Default::default()
+        };
+        let res = match client.create_exec(&container.id, create).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::debug!(%e, "create_exec for in-container kill failed");
+                return;
+            }
+        };
+        // `detach: true` makes start_exec return as soon as the docker
+        // daemon has spawned the kill; we don't need to stream its
+        // (empty) output.
+        let opts = StartExecOptions {
+            detach: true,
+            ..Default::default()
+        };
+        if let Err(e) = client.start_exec(&res.id, Some(opts)).await {
+            tracing::debug!(%e, "start_exec for in-container kill failed");
+        }
+    }
 }
 
 /// `devcontainer build` — build a dev container image.

--- a/crates/devcontainer-mcp-core/src/devpod.rs
+++ b/crates/devcontainer-mcp-core/src/devpod.rs
@@ -2,7 +2,9 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
-use crate::cli::{run_cli, run_with_shim, ChunkSink, CliBinary, CliOutput, RemoteKiller};
+use crate::cli::{
+    run_cli, run_cli_streaming, run_with_shim, ChunkSink, CliBinary, CliOutput, RemoteKiller,
+};
 use crate::error::{Error, Result};
 
 /// Run a devpod CLI command with the given args.
@@ -31,6 +33,45 @@ pub async fn up(args: &[&str]) -> Result<CliOutput> {
     run_devpod(&cmd_args, false).await
 }
 
+/// `devpod up` — cancellable, streaming variant.
+///
+/// Provisioning a cloud workspace (especially the GCP/AWS/Azure
+/// providers) can take 2–10 minutes. Wrapping `devpod up` through
+/// [`run_cli_streaming`] gives us two things:
+///
+/// 1. **Cancellation**: when the client times out and sends
+///    `notifications/cancelled`, our handler's [`CancellationToken`]
+///    fires and we reap the host process tree (the `devpod` CLI and
+///    its descendants). Devpod's own cleanup logic then unwinds any
+///    partial cloud resources (it has rollback semantics for failed
+///    `up`).
+///
+/// 2. **Progress notifications**: every line of `devpod up` output
+///    ("Creating devcontainer...", "npm install...", …) is forwarded
+///    as an MCP progress notification, keeping the wire warm so
+///    idle-based client timeouts don't trip.
+///
+/// Unlike `ssh_exec_streaming` this path uses [`run_cli_streaming`]
+/// directly — no shim is needed because `devpod up` runs entirely on
+/// the host (it makes GCP API calls; no remote process to reap).
+pub async fn up_streaming(
+    args: &[&str],
+    cancel: &CancellationToken,
+    on_chunk: Option<Arc<dyn ChunkSink>>,
+) -> Result<CliOutput> {
+    let mut cmd_args = vec!["up", "--open-ide=false"];
+    cmd_args.extend_from_slice(args);
+    run_cli_streaming(
+        &CliBinary::DevPod,
+        &cmd_args,
+        false,
+        None,
+        cancel,
+        on_chunk,
+    )
+    .await
+}
+
 /// `devpod stop` — stop a workspace.
 pub async fn stop(workspace: &str) -> Result<CliOutput> {
     run_devpod(&["stop", workspace], false).await
@@ -50,6 +91,25 @@ pub async fn build(args: &[&str]) -> Result<CliOutput> {
     let mut cmd_args = vec!["build"];
     cmd_args.extend_from_slice(args);
     run_devpod(&cmd_args, false).await
+}
+
+/// `devpod build` — cancellable, streaming variant. See [`up_streaming`].
+pub async fn build_streaming(
+    args: &[&str],
+    cancel: &CancellationToken,
+    on_chunk: Option<Arc<dyn ChunkSink>>,
+) -> Result<CliOutput> {
+    let mut cmd_args = vec!["build"];
+    cmd_args.extend_from_slice(args);
+    run_cli_streaming(
+        &CliBinary::DevPod,
+        &cmd_args,
+        false,
+        None,
+        cancel,
+        on_chunk,
+    )
+    .await
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/devcontainer-mcp-core/src/devpod.rs
+++ b/crates/devcontainer-mcp-core/src/devpod.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
 
-use crate::cli::{run_cli, CliBinary, CliOutput};
+use crate::cli::{run_cli, run_with_shim, ChunkSink, CliBinary, CliOutput, RemoteKiller};
 use crate::error::{Error, Result};
 
 /// Run a devpod CLI command with the given args.
@@ -106,6 +108,88 @@ pub async fn ssh_exec(
         args.push(w);
     }
     run_devpod(&args, false).await
+}
+
+/// `devpod ssh --command` — cancellable, streaming variant.
+///
+/// Same shim treatment as [`crate::devcontainer::exec_streaming`]: the
+/// user's command is wrapped with [`crate::exec_shim::wrap_self_contained`]
+/// so it survives the SSH transport without quoting hazards, the
+/// captured remote PGID is stripped from stderr, and on cancel a
+/// second `devpod ssh --command` delivers `kill -TERM -<pgid>` then
+/// `kill -KILL -<pgid>` to the same workspace.
+///
+/// DevPod (unlike the devcontainer CLI) has no `--remote-env` flag,
+/// hence the self-contained shim variant which embeds the user
+/// command as a base64 blob inside the shell snippet.
+pub async fn ssh_exec_streaming(
+    workspace: &str,
+    command: &str,
+    user: Option<&str>,
+    workdir: Option<&str>,
+    cancel: &CancellationToken,
+    on_chunk: Option<Arc<dyn ChunkSink>>,
+) -> Result<CliOutput> {
+    let wrapped = crate::exec_shim::wrap_self_contained(command);
+    let mut args = vec!["ssh", workspace, "--command", &wrapped];
+    if let Some(u) = user {
+        args.push("--user");
+        args.push(u);
+    }
+    if let Some(w) = workdir {
+        args.push("--workdir");
+        args.push(w);
+    }
+
+    let killer: Arc<dyn RemoteKiller> = Arc::new(DevpodKiller {
+        workspace: workspace.to_string(),
+        user: user.map(str::to_string),
+    });
+
+    run_with_shim(
+        &CliBinary::DevPod,
+        &args,
+        None,
+        cancel,
+        on_chunk,
+        killer,
+    )
+    .await
+}
+
+/// Delivers `kill -<sig> -<pgid>` inside a DevPod workspace by
+/// spawning a fresh short-lived `devpod ssh --command "kill ..."`.
+///
+/// We can't reuse the original SSH session (it's busy running the
+/// workload that we're trying to interrupt), so each kill is its own
+/// `devpod ssh` round trip. This is slower than the docker exec path
+/// — SSH auth handshake plus DevPod's own session setup — but cancel
+/// is a rare path and we'd rather pay 1–2 seconds of latency than
+/// leak the workload.
+struct DevpodKiller {
+    workspace: String,
+    user: Option<String>,
+}
+
+#[async_trait::async_trait]
+impl RemoteKiller for DevpodKiller {
+    async fn kill_pgid(&self, pgid: i32, signal: &str) {
+        // `kill -<sig> -<pgid>` with the same BusyBox-friendly form
+        // we use for the devcontainer backend (no `--`).
+        let cmd = format!("kill -{signal} -{pgid} 2>/dev/null || true");
+        let mut args = vec!["ssh", &self.workspace, "--command", &cmd];
+        if let Some(u) = self.user.as_deref() {
+            args.push("--user");
+            args.push(u);
+        }
+        // Use the plain (non-streaming, non-cancellable) runner so we
+        // don't recursively pull in the whole shim machinery for a
+        // 50-byte one-shot. We swallow errors: a kill that fails
+        // because the target has already exited is fine.
+        if let Err(e) = run_cli(&CliBinary::DevPod, &args, false).await {
+            tracing::debug!(%e, pgid, signal, "devpod ssh kill failed");
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/devcontainer-mcp-core/src/error.rs
+++ b/crates/devcontainer-mcp-core/src/error.rs
@@ -36,6 +36,9 @@ pub enum Error {
     #[error("File edit error: {0}")]
     FileEdit(String),
 
+    #[error("Operation cancelled by peer")]
+    Cancelled,
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/crates/devcontainer-mcp-core/src/exec_shim.rs
+++ b/crates/devcontainer-mcp-core/src/exec_shim.rs
@@ -103,15 +103,33 @@ pub fn wrap_self_contained(user_cmd: &str) -> String {
     )
 }
 
-/// If `line` is the shim's sentinel, return the captured PGID.
+/// If `line` contains the shim's sentinel, return the captured PGID.
 /// Otherwise return `None`. The caller should suppress matching lines
 /// from any downstream output.
+///
+/// We accept the sentinel anywhere within the line, not just as a
+/// standalone match, because intermediate transports decorate remote
+/// stderr with prefixes that vary by backend:
+///   - `gh codespace ssh`: passes lines through unmodified.
+///   - `devpod ssh`: prefixes each line with ANSI color codes, a
+///     timestamp, and an `info`/`error` log-level tag.
+///   - Future backends may layer on their own prefixes.
+///
+/// The sentinel itself (`__DCMCP_PGID=NNN__`) is intentionally
+/// distinctive — both delimiters are `__DCMCP_*__` — so the chance
+/// of a false positive from user output containing that exact byte
+/// sequence is vanishingly small. Bounding the digit count to 31
+/// bits keeps us safe against malformed input that would otherwise
+/// trip `parse`'s overflow check.
 pub fn try_parse_sentinel(line: &str) -> Option<i32> {
-    // Match `^\s*__DCMCP_PGID=(\d+)__\s*$`. A hand-rolled scan keeps
-    // the dependency footprint at zero.
-    let trimmed = line.trim();
-    let rest = trimmed.strip_prefix(SENTINEL_PREFIX)?;
-    let num = rest.strip_suffix(SENTINEL_SUFFIX)?;
+    // Locate the prefix; bail if absent.
+    let after_prefix = line.find(SENTINEL_PREFIX)
+        .map(|i| &line[i + SENTINEL_PREFIX.len()..])?;
+    // The PGID runs from here to the next `__` (the suffix). Look
+    // forward for the suffix; if not found, this isn't our sentinel
+    // (could be a substring collision in user output).
+    let end = after_prefix.find(SENTINEL_SUFFIX)?;
+    let num = &after_prefix[..end];
     if num.is_empty() || !num.bytes().all(|b| b.is_ascii_digit()) {
         return None;
     }
@@ -168,12 +186,35 @@ mod tests {
     }
 
     #[test]
+    fn try_parse_sentinel_accepts_decorated_lines() {
+        // Real-world cases observed against backend transports that
+        // decorate remote stderr with their own prefixes:
+        //
+        // - devpod ssh prepends ANSI color codes + timestamp + log level.
+        // - Some shells may inject ESC sequences from PROMPT_COMMAND
+        //   into stderr on first connection.
+        //
+        // The sentinel itself is distinctive enough that "anywhere in
+        // the line" is safe in practice.
+        assert_eq!(
+            try_parse_sentinel("\u{1b}[0;1;36minfo \u{1b}[0m__DCMCP_PGID=385__"),
+            Some(385),
+        );
+        assert_eq!(
+            try_parse_sentinel("[19:05:32] info __DCMCP_PGID=12345__"),
+            Some(12345),
+        );
+    }
+
+    #[test]
     fn try_parse_sentinel_rejects_garbage() {
         assert_eq!(try_parse_sentinel("hello"), None);
         assert_eq!(try_parse_sentinel("__DCMCP_PGID=abc__"), None);
         assert_eq!(try_parse_sentinel("PGID=42"), None);
-        // Don't accept it embedded in other text:
-        assert_eq!(try_parse_sentinel("prefix __DCMCP_PGID=42__"), None);
+        // Truncated (no terminator) — must not match.
+        assert_eq!(try_parse_sentinel("__DCMCP_PGID=42"), None);
+        // Missing PGID number.
+        assert_eq!(try_parse_sentinel("__DCMCP_PGID=__"), None);
     }
 
     #[test]

--- a/crates/devcontainer-mcp-core/src/exec_shim.rs
+++ b/crates/devcontainer-mcp-core/src/exec_shim.rs
@@ -70,6 +70,39 @@ fi"#,
 /// before invoking the shim string.
 pub const USER_CMD_ENV: &str = "DCMCP_USER_CMD";
 
+/// Self-contained variant of [`wrap`] that embeds the user command
+/// directly in the returned shell string as a base64 blob.
+///
+/// Use this when the backend transport can carry a shell command but
+/// cannot propagate environment variables — e.g. `devpod ssh
+/// --command <cmd>` and `gh codespace ssh -- <cmd>`, neither of which
+/// has a `--remote-env`-style flag.
+///
+/// The returned string is shell-safe regardless of what's in
+/// `user_cmd`: the user command is encoded once on the host and
+/// decoded once on the target, with no intermediate shell layers
+/// re-interpreting its quoting.
+pub fn wrap_self_contained(user_cmd: &str) -> String {
+    use base64::{engine::general_purpose::STANDARD, Engine};
+
+    let encoded = STANDARD.encode(user_cmd.as_bytes());
+    // The shell decodes the blob into `DCMCP_USER_CMD` and then runs
+    // the standard shim, which already knows how to eval that env
+    // var. This keeps the two shim flavors structurally identical and
+    // means a single sentinel parser handles both.
+    //
+    // We require `base64` on the target. It is present in every
+    // container image we've encountered (coreutils, busybox, alpine)
+    // because the file-write path already depends on it.
+    let shim = wrap();
+    format!(
+        "{env}=$(printf '%s' '{encoded}' | base64 -d) && export {env} && {shim}",
+        env = USER_CMD_ENV,
+        encoded = encoded,
+        shim = shim,
+    )
+}
+
 /// If `line` is the shim's sentinel, return the captured PGID.
 /// Otherwise return `None`. The caller should suppress matching lines
 /// from any downstream output.
@@ -162,5 +195,42 @@ mod tests {
             .find_map(try_parse_sentinel)
             .expect("sentinel emitted");
         assert!(pgid > 0);
+    }
+
+    #[test]
+    fn wrap_self_contained_runs_user_cmd_with_no_env() {
+        // The whole point of the self-contained variant: no env var
+        // setup, command flows through the shell string itself.
+        let wrapped = wrap_self_contained(r#"echo "it's a (self-contained) test""#);
+        let out = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(&wrapped)
+            .output()
+            .expect("spawn");
+        assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stdout.contains("it's a (self-contained) test"), "stdout: {stdout:?}");
+        assert!(
+            stderr.lines().any(|l| try_parse_sentinel(l).is_some()),
+            "no sentinel in stderr: {stderr:?}"
+        );
+    }
+
+    #[test]
+    fn wrap_self_contained_preserves_arbitrary_bytes() {
+        // Pathological user command: single quotes, double quotes,
+        // backticks, dollar signs, backslashes, newlines, parens.
+        let user_cmd = "echo 'a' \"b\" `echo c` $((1+1)) \\\\ \n echo done";
+        let wrapped = wrap_self_contained(user_cmd);
+        let out = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(&wrapped)
+            .output()
+            .expect("spawn");
+        assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(stdout.contains("a b c 2"), "stdout: {stdout:?}");
+        assert!(stdout.contains("done"), "stdout: {stdout:?}");
     }
 }

--- a/crates/devcontainer-mcp-core/src/exec_shim.rs
+++ b/crates/devcontainer-mcp-core/src/exec_shim.rs
@@ -1,0 +1,166 @@
+//! In-target process-group shim for cancellable cross-boundary execs.
+//!
+//! When we run a command across a process boundary (host → container via
+//! `docker exec`, host → VM via SSH, …) we lose direct ancestry control:
+//! the target-side processes do not appear as descendants of any host PID
+//! we own. SIGTERM'ing our host-side wrapper closes the stdio pipes but
+//! leaves the actual workload running, reparented to the target's init.
+//!
+//! To regain control we wrap the user's command with a tiny shim that:
+//!   1. Runs the user command in a fresh session (`setsid`), so the
+//!      leaf shell's PID is also its process group ID (PGID), and the
+//!      PGID transitively addresses every descendant.
+//!   2. Emits a recognizable sentinel on stderr containing that PGID,
+//!      so the host-side reader can capture it.
+//!
+//! On cancellation, the host sends `kill -- -<pgid>` *inside the target*
+//! (via the backend's exec channel — `docker exec`, `devpod ssh`, etc.),
+//! which reaps the entire process group atomically.
+
+/// Marker that brackets the PGID line so we can find and strip it from
+/// stderr without false positives from user output.
+const SENTINEL_PREFIX: &str = "__DCMCP_PGID=";
+const SENTINEL_SUFFIX: &str = "__";
+
+/// Wrap a user-supplied shell command with the shim prelude.
+///
+/// The returned string is intended to be passed as a single argument to
+/// `sh -c` (or any POSIX shell) on the target. It expects to find the
+/// user's command in the environment variable [`USER_CMD_ENV`] (see
+/// [`USER_CMD_ENV`] for the name) — passing it that way avoids the
+/// quoting hazards of nesting `sh -c '...'` inside another `sh -c '...'`
+/// when the user command itself contains single quotes, parentheses, or
+/// other shell metacharacters.
+///
+/// The shim runs the user command via `eval`, in a fresh session
+/// (`setsid`) so the leaf shell's PID is also its process group ID
+/// (PGID), and prints `__DCMCP_PGID=<pid>__` to stderr once for the
+/// host-side reader to capture.
+pub fn wrap() -> String {
+    // We deliberately keep this string free of any user-supplied
+    // content. Every variable expansion comes from the target shell's
+    // environment, not from string interpolation on the host.
+    //
+    // We background the `setsid` child and `wait` on it instead of
+    // using `setsid -w` because the `-w` flag is util-linux–only:
+    // busybox/alpine images ship a `setsid` without it. Backgrounding
+    // + `wait` is POSIX and works on every shell we care about.
+    //
+    // The trailing `exit "$?"` propagates the inner program's exit
+    // code back up to the outer `sh -c` so `devcontainer exec`
+    // returns the correct status.
+    format!(
+        r#"if command -v setsid >/dev/null 2>&1; then
+  setsid sh -c 'printf "{prefix}%s{suffix}\n" "$$" 1>&2; eval "${env}"' &
+  __dcmcp_pid=$!
+  wait "$__dcmcp_pid"
+  exit "$?"
+else
+  printf "{prefix}%s{suffix}\n" "$$" 1>&2
+  eval "${env}"
+fi"#,
+        prefix = SENTINEL_PREFIX,
+        suffix = SENTINEL_SUFFIX,
+        env = USER_CMD_ENV,
+    )
+}
+
+/// Environment variable through which the wrapped shim receives the
+/// user command. Callers must set this in the spawned process's env
+/// before invoking the shim string.
+pub const USER_CMD_ENV: &str = "DCMCP_USER_CMD";
+
+/// If `line` is the shim's sentinel, return the captured PGID.
+/// Otherwise return `None`. The caller should suppress matching lines
+/// from any downstream output.
+pub fn try_parse_sentinel(line: &str) -> Option<i32> {
+    // Match `^\s*__DCMCP_PGID=(\d+)__\s*$`. A hand-rolled scan keeps
+    // the dependency footprint at zero.
+    let trimmed = line.trim();
+    let rest = trimmed.strip_prefix(SENTINEL_PREFIX)?;
+    let num = rest.strip_suffix(SENTINEL_SUFFIX)?;
+    if num.is_empty() || !num.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    num.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrap_emits_sentinel_and_runs_user_cmd() {
+        // Smoke test: pass user cmd via env, confirm stdout has the
+        // user output and stderr has the sentinel.
+        let wrapped = wrap();
+        let out = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(&wrapped)
+            .env(USER_CMD_ENV, "echo hello")
+            .output()
+            .expect("spawn sh");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stdout.contains("hello"), "stdout: {stdout:?}");
+        assert!(
+            stderr.lines().any(|l| try_parse_sentinel(l).is_some()),
+            "no sentinel in stderr: {stderr:?}"
+        );
+    }
+
+    #[test]
+    fn wrap_handles_metacharacters_in_user_cmd() {
+        // The whole reason wrap() reads from env: user commands with
+        // single quotes, parens, subshells, etc. must not break the
+        // shim's own quoting.
+        let wrapped = wrap();
+        let evil = r#"(echo "it's a (test)" & echo $((1+2)) ) | tr a-z A-Z"#;
+        let out = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(&wrapped)
+            .env(USER_CMD_ENV, evil)
+            .output()
+            .expect("spawn sh");
+        assert!(out.status.success(), "stderr: {:?}", String::from_utf8_lossy(&out.stderr));
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(stdout.contains("IT'S A (TEST)"), "stdout: {stdout:?}");
+        assert!(stdout.contains("3"), "stdout missing arithmetic: {stdout:?}");
+    }
+
+    #[test]
+    fn try_parse_sentinel_matches() {
+        assert_eq!(try_parse_sentinel("__DCMCP_PGID=42__"), Some(42));
+        assert_eq!(try_parse_sentinel("  __DCMCP_PGID=12345__  "), Some(12345));
+    }
+
+    #[test]
+    fn try_parse_sentinel_rejects_garbage() {
+        assert_eq!(try_parse_sentinel("hello"), None);
+        assert_eq!(try_parse_sentinel("__DCMCP_PGID=abc__"), None);
+        assert_eq!(try_parse_sentinel("PGID=42"), None);
+        // Don't accept it embedded in other text:
+        assert_eq!(try_parse_sentinel("prefix __DCMCP_PGID=42__"), None);
+    }
+
+    #[test]
+    fn sentinel_pgid_actually_addresses_descendants() {
+        // Run a sleep in the background under the shim and verify the
+        // emitted PGID > 0 (round-trip parse). We can't safely kill
+        // the group here without affecting the test runner, so the
+        // end-to-end kill is tested by the cli integration test.
+        let wrapped = wrap();
+        let out = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(&wrapped)
+            .env(USER_CMD_ENV, "sleep 0.2 & wait")
+            .output()
+            .expect("spawn");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let pgid = stderr
+            .lines()
+            .find_map(try_parse_sentinel)
+            .expect("sentinel emitted");
+        assert!(pgid > 0);
+    }
+}

--- a/crates/devcontainer-mcp-core/src/file_ops.rs
+++ b/crates/devcontainer-mcp-core/src/file_ops.rs
@@ -53,10 +53,15 @@ pub fn apply_edit(content: &str, old_str: &str, new_str: &str) -> Result<String>
 }
 
 /// Shell-escape a string for safe embedding in a shell command.
-fn quote(s: &str) -> String {
+pub fn shell_quote(s: &str) -> String {
     shlex::try_quote(s)
         .unwrap_or(std::borrow::Cow::Borrowed(s))
         .into_owned()
+}
+
+/// Convenience alias for module-local use.
+fn quote(s: &str) -> String {
+    shell_quote(s)
 }
 
 /// Build a shell command that reads a file via `cat`.

--- a/crates/devcontainer-mcp-core/src/lib.rs
+++ b/crates/devcontainer-mcp-core/src/lib.rs
@@ -5,4 +5,6 @@ pub mod devcontainer;
 pub mod devpod;
 pub mod docker;
 pub mod error;
+pub mod exec_shim;
 pub mod file_ops;
+pub mod process_tree;

--- a/crates/devcontainer-mcp-core/src/process_tree.rs
+++ b/crates/devcontainer-mcp-core/src/process_tree.rs
@@ -1,0 +1,215 @@
+//! Process-tree reaping.
+//!
+//! When a CLI we spawned crosses a process boundary (e.g. `devcontainer
+//! exec` → `docker exec` → containerd-shim → user command inside the
+//! container), simply SIGTERM'ing our immediate child does not kill the
+//! actual work — the in-container processes are reparented to the
+//! container's PID 1 and keep running. They consume CPU, hold locks,
+//! and never exit.
+//!
+//! On Linux, every process in any namespace still has a host-visible PID
+//! in the root PID namespace, and `/proc/<pid>/status` exposes its parent
+//! as `PPid:`. So from our root child PID we can BFS the full set of
+//! descendants and terminate them ourselves — no in-container shim, no
+//! cooperation from the backend CLI required.
+//!
+//! Non-Linux platforms get a no-op fallback that only signals the root
+//! PID; this is fine because dev containers are a Linux-host feature.
+
+use std::time::Duration;
+
+/// Reap a process tree rooted at `root_pid`.
+///
+/// 1. Discover every descendant of `root_pid` (including `root_pid` itself)
+///    by walking `/proc/*/status`.
+/// 2. Send `SIGTERM` to all of them.
+/// 3. Wait up to `grace` for them to exit.
+/// 4. Send `SIGKILL` to any survivors.
+///
+/// Best-effort: any individual `/proc` read or `kill(2)` is allowed to
+/// fail silently (the process may have already exited). The function
+/// returns when the grace period is up; it does not guarantee every PID
+/// is gone (a process can ignore SIGKILL only if it is uninterruptible
+/// in the kernel, which is out of our control).
+pub async fn reap(root_pid: u32, grace: Duration) {
+    #[cfg(target_os = "linux")]
+    {
+        reap_linux(root_pid, grace).await;
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        // Fallback: signal the root only. Container reaping requires
+        // /proc-style introspection which we don't have here.
+        let _ = (root_pid, grace);
+        #[cfg(unix)]
+        unsafe {
+            libc::kill(root_pid as i32, libc::SIGTERM);
+            tokio::time::sleep(grace).await;
+            libc::kill(root_pid as i32, libc::SIGKILL);
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn reap_linux(root_pid: u32, grace: Duration) {
+    // Snapshot the full descendant set. We do this once, send SIGTERM,
+    // wait, then re-discover for SIGKILL (new grandchildren may have
+    // appeared during the grace period — e.g. a `go test` runner that
+    // spawned its own test binaries while we were waiting).
+    let initial = collect_descendants(root_pid);
+    tracing::debug!(
+        root = root_pid,
+        n = initial.len(),
+        "reap: SIGTERM descendants"
+    );
+    signal_all(&initial, libc_signal::SIGTERM);
+
+    // Wait for graceful exit. Short-circuit if everyone is already gone.
+    let deadline = std::time::Instant::now() + grace;
+    while std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if !any_alive(&initial) {
+            tracing::debug!(root = root_pid, "reap: all descendants exited cleanly");
+            return;
+        }
+    }
+
+    // Re-discover and SIGKILL anything still around. We re-walk /proc
+    // because the surviving tree may have grown.
+    let survivors = collect_descendants(root_pid);
+    if !survivors.is_empty() {
+        tracing::warn!(
+            root = root_pid,
+            n = survivors.len(),
+            "reap: SIGKILL survivors"
+        );
+        signal_all(&survivors, libc_signal::SIGKILL);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn collect_descendants(root: u32) -> Vec<u32> {
+    // Build a parent → children map by scanning /proc/*/status. This is
+    // O(N) where N is the number of processes on the host. For typical
+    // dev machines (a few hundred procs) this is sub-millisecond.
+    use std::collections::HashMap;
+
+    let mut children_of: HashMap<u32, Vec<u32>> = HashMap::new();
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return vec![root];
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else { continue };
+        let Ok(pid) = name_str.parse::<u32>() else { continue };
+        if let Some(ppid) = read_ppid(pid) {
+            children_of.entry(ppid).or_default().push(pid);
+        }
+    }
+
+    // BFS from `root`. Include `root` itself so the caller can kill the
+    // whole tree in one pass.
+    let mut out = Vec::new();
+    let mut stack = vec![root];
+    while let Some(pid) = stack.pop() {
+        out.push(pid);
+        if let Some(kids) = children_of.get(&pid) {
+            stack.extend_from_slice(kids);
+        }
+    }
+    out
+}
+
+#[cfg(target_os = "linux")]
+fn read_ppid(pid: u32) -> Option<u32> {
+    // `/proc/<pid>/status` is line-oriented. We only need the `PPid:`
+    // line, which appears near the top, so reading the whole file is
+    // wasteful but trivial in size.
+    let status = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("PPid:") {
+            return rest.trim().parse().ok();
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn signal_all(pids: &[u32], sig: i32) {
+    for &pid in pids {
+        // kill(2) can fail with ESRCH if the process already exited;
+        // EPERM if we don't own it (shouldn't happen for our descendants
+        // unless they did a setuid). Either way, swallow.
+        unsafe {
+            libc::kill(pid as i32, sig);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn signal_all(_: &[u32], _: i32) {}
+
+#[cfg(target_os = "linux")]
+fn any_alive(pids: &[u32]) -> bool {
+    pids.iter().any(|&pid| {
+        // kill(pid, 0) probes existence + permission without sending a
+        // signal. Returns 0 if the process exists and we can signal it.
+        unsafe { libc::kill(pid as i32, 0) == 0 }
+    })
+}
+
+#[cfg(unix)]
+mod libc_signal {
+    pub const SIGTERM: i32 = libc::SIGTERM;
+    pub const SIGKILL: i32 = libc::SIGKILL;
+}
+
+#[cfg(not(unix))]
+mod libc_signal {
+    pub const SIGTERM: i32 = 15;
+    pub const SIGKILL: i32 = 9;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn read_ppid_for_self() {
+        let pid = std::process::id();
+        let ppid = read_ppid(pid).expect("self has a PPid");
+        // Whatever launched the test runner.
+        assert!(ppid > 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn descendants_includes_root() {
+        let pid = std::process::id();
+        let set = collect_descendants(pid);
+        assert!(set.contains(&pid));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn reap_kills_a_child_tree() {
+        // Spawn `sh -c 'sleep 30 & sleep 30 & wait'` and reap it.
+        let mut child = tokio::process::Command::new("sh")
+            .args(["-c", "sleep 30 & sleep 30 & wait"])
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn");
+        let root = child.id().expect("pid");
+        // Let the grandchildren actually exist before we reap.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let before = collect_descendants(root);
+        assert!(before.len() >= 3, "expected root + 2 sleeps, got {before:?}");
+
+        reap(root, Duration::from_secs(1)).await;
+        // Give the kernel a moment to actually reap zombies.
+        let _ = child.wait().await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(!any_alive(&before), "some descendants survived: {before:?}");
+    }
+}

--- a/crates/devcontainer-mcp/Cargo.toml
+++ b/crates/devcontainer-mcp/Cargo.toml
@@ -18,3 +18,5 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 schemars = "1"
 shlex = "1"
+async-trait = "0.1"
+tokio-util = "0.7"

--- a/crates/devcontainer-mcp/src/tools/codespaces/create.rs
+++ b/crates/devcontainer-mcp/src/tools/codespaces/create.rs
@@ -1,8 +1,11 @@
 use devcontainer_mcp_core::{auth, codespaces};
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::{tool, tool_router};
+use rmcp::model::Meta;
+use rmcp::service::Peer;
+use rmcp::{tool, tool_router, RoleServer};
+use tokio_util::sync::CancellationToken;
 
-use crate::tools::common::format_output;
+use crate::tools::common::{format_output, progress_sink_from_meta};
 use crate::tools::DevContainerMcp;
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
@@ -36,12 +39,16 @@ impl DevContainerMcp {
     async fn codespaces_create(
         &self,
         Parameters(params): Parameters<CodespacesCreateParams>,
+        ct: CancellationToken,
+        peer: Peer<RoleServer>,
+        meta: Meta,
     ) -> String {
         let env = match auth::resolve_handle_env(&params.auth).await {
             Ok(e) => e,
             Err(e) => return format!("Auth error: {e}"),
         };
-        match codespaces::create(
+        let sink = progress_sink_from_meta(&meta, &peer);
+        match codespaces::create_streaming(
             &env,
             &params.repo,
             params.branch.as_deref(),
@@ -49,6 +56,8 @@ impl DevContainerMcp {
             params.devcontainer_path.as_deref(),
             params.display_name.as_deref(),
             params.idle_timeout.as_deref(),
+            &ct,
+            sink,
         )
         .await
         {

--- a/crates/devcontainer-mcp/src/tools/codespaces/ssh.rs
+++ b/crates/devcontainer-mcp/src/tools/codespaces/ssh.rs
@@ -1,6 +1,12 @@
+use std::sync::Arc;
+
+use devcontainer_mcp_core::cli::{ChunkSink, OutputChunk, OutputStream};
 use devcontainer_mcp_core::{auth, codespaces};
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::{tool, tool_router};
+use rmcp::model::{Meta, ProgressNotificationParam, ProgressToken};
+use rmcp::service::Peer;
+use rmcp::{tool, tool_router, RoleServer};
+use tokio_util::sync::CancellationToken;
 
 use crate::tools::common::format_output;
 use crate::tools::DevContainerMcp;
@@ -15,18 +21,68 @@ struct CodespacesSshParams {
     command: String,
 }
 
+/// See the devcontainer/exec.rs version for full commentary; this is a
+/// near-identical copy specialized to the Codespaces backend.
+struct ProgressChunkSink {
+    peer: Peer<RoleServer>,
+    progress_token: ProgressToken,
+    counter: std::sync::atomic::AtomicU64,
+}
+
+#[async_trait::async_trait]
+impl ChunkSink for ProgressChunkSink {
+    async fn on_chunk(&self, chunk: OutputChunk) {
+        let n = self
+            .counter
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        let prefix = match chunk.stream {
+            OutputStream::Stdout => "stdout",
+            OutputStream::Stderr => "stderr",
+        };
+        let param = ProgressNotificationParam::new(self.progress_token.clone(), n as f64)
+            .with_message(format!("{prefix}: {}", chunk.line));
+        if let Err(e) = self.peer.notify_progress(param).await {
+            tracing::debug!(%e, "failed to send progress notification");
+        }
+    }
+}
+
 #[tool_router(router = codespaces_ssh_router, vis = "pub(super)")]
 impl DevContainerMcp {
     #[tool(
         name = "codespaces_ssh",
         description = "Execute a command inside a GitHub Codespace via SSH. Requires a GitHub auth handle."
     )]
-    async fn codespaces_ssh(&self, Parameters(params): Parameters<CodespacesSshParams>) -> String {
+    async fn codespaces_ssh(
+        &self,
+        Parameters(params): Parameters<CodespacesSshParams>,
+        ct: CancellationToken,
+        peer: Peer<RoleServer>,
+        meta: Meta,
+    ) -> String {
         let env = match auth::resolve_handle_env(&params.auth).await {
             Ok(e) => e,
             Err(e) => return format!("Auth error: {e}"),
         };
-        match codespaces::ssh_exec(&env, &params.codespace, &params.command).await {
+
+        let sink: Option<Arc<dyn ChunkSink>> = meta.get_progress_token().map(|token| {
+            Arc::new(ProgressChunkSink {
+                peer: peer.clone(),
+                progress_token: token,
+                counter: std::sync::atomic::AtomicU64::new(0),
+            }) as Arc<dyn ChunkSink>
+        });
+
+        match codespaces::ssh_exec_streaming(
+            &env,
+            &params.codespace,
+            &params.command,
+            &ct,
+            sink,
+        )
+        .await
+        {
             Ok(output) => format_output(&output),
             Err(e) => format!("Error: {e}"),
         }

--- a/crates/devcontainer-mcp/src/tools/codespaces/ssh.rs
+++ b/crates/devcontainer-mcp/src/tools/codespaces/ssh.rs
@@ -1,14 +1,11 @@
-use std::sync::Arc;
-
-use devcontainer_mcp_core::cli::{ChunkSink, OutputChunk, OutputStream};
 use devcontainer_mcp_core::{auth, codespaces};
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{Meta, ProgressNotificationParam, ProgressToken};
+use rmcp::model::Meta;
 use rmcp::service::Peer;
 use rmcp::{tool, tool_router, RoleServer};
 use tokio_util::sync::CancellationToken;
 
-use crate::tools::common::format_output;
+use crate::tools::common::{format_output, progress_sink_from_meta};
 use crate::tools::DevContainerMcp;
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
@@ -19,33 +16,6 @@ struct CodespacesSshParams {
     codespace: String,
     #[schemars(description = "Command to execute inside the codespace")]
     command: String,
-}
-
-/// See the devcontainer/exec.rs version for full commentary; this is a
-/// near-identical copy specialized to the Codespaces backend.
-struct ProgressChunkSink {
-    peer: Peer<RoleServer>,
-    progress_token: ProgressToken,
-    counter: std::sync::atomic::AtomicU64,
-}
-
-#[async_trait::async_trait]
-impl ChunkSink for ProgressChunkSink {
-    async fn on_chunk(&self, chunk: OutputChunk) {
-        let n = self
-            .counter
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            + 1;
-        let prefix = match chunk.stream {
-            OutputStream::Stdout => "stdout",
-            OutputStream::Stderr => "stderr",
-        };
-        let param = ProgressNotificationParam::new(self.progress_token.clone(), n as f64)
-            .with_message(format!("{prefix}: {}", chunk.line));
-        if let Err(e) = self.peer.notify_progress(param).await {
-            tracing::debug!(%e, "failed to send progress notification");
-        }
-    }
 }
 
 #[tool_router(router = codespaces_ssh_router, vis = "pub(super)")]
@@ -66,22 +36,10 @@ impl DevContainerMcp {
             Err(e) => return format!("Auth error: {e}"),
         };
 
-        let sink: Option<Arc<dyn ChunkSink>> = meta.get_progress_token().map(|token| {
-            Arc::new(ProgressChunkSink {
-                peer: peer.clone(),
-                progress_token: token,
-                counter: std::sync::atomic::AtomicU64::new(0),
-            }) as Arc<dyn ChunkSink>
-        });
+        let sink = progress_sink_from_meta(&meta, &peer);
 
-        match codespaces::ssh_exec_streaming(
-            &env,
-            &params.codespace,
-            &params.command,
-            &ct,
-            sink,
-        )
-        .await
+        match codespaces::ssh_exec_streaming(&env, &params.codespace, &params.command, &ct, sink)
+            .await
         {
             Ok(output) => format_output(&output),
             Err(e) => format!("Error: {e}"),

--- a/crates/devcontainer-mcp/src/tools/common.rs
+++ b/crates/devcontainer-mcp/src/tools/common.rs
@@ -1,4 +1,10 @@
-use devcontainer_mcp_core::cli::CliOutput;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use devcontainer_mcp_core::cli::{ChunkSink, CliOutput, OutputChunk, OutputStream};
+use rmcp::model::{Meta, ProgressNotificationParam, ProgressToken};
+use rmcp::service::Peer;
+use rmcp::RoleServer;
 
 /// Format a CliOutput as a JSON string for MCP responses.
 pub fn format_output(output: &CliOutput) -> String {
@@ -9,4 +15,57 @@ pub fn format_output(output: &CliOutput) -> String {
         "json": output.json,
     })
     .to_string()
+}
+
+/// Forwards every line of child output to the MCP peer as a
+/// `notifications/progress` message. Used by all long-running tools
+/// (`*_exec`, `*_ssh`, `*_up`, `*_build`, `codespaces_create`) so
+/// clients can render progress and so idle-based client timeouts
+/// don't trip on multi-minute operations.
+///
+/// The MCP spec requires a strictly-increasing `progress` value on
+/// every notification with the same token, hence the per-sink
+/// atomic counter.
+struct ProgressChunkSink {
+    peer: Peer<RoleServer>,
+    progress_token: ProgressToken,
+    counter: AtomicU64,
+}
+
+#[async_trait::async_trait]
+impl ChunkSink for ProgressChunkSink {
+    async fn on_chunk(&self, chunk: OutputChunk) {
+        let n = self.counter.fetch_add(1, Ordering::Relaxed) + 1;
+        let prefix = match chunk.stream {
+            OutputStream::Stdout => "stdout",
+            OutputStream::Stderr => "stderr",
+        };
+        let param = ProgressNotificationParam::new(self.progress_token.clone(), n as f64)
+            .with_message(format!("{prefix}: {}", chunk.line));
+        if let Err(e) = self.peer.notify_progress(param).await {
+            // Sink errors are non-fatal: the peer may have
+            // disconnected or simply not subscribed to progress.
+            // We still want the child to keep running and produce
+            // a final response (which may or may not get delivered).
+            tracing::debug!(%e, "failed to send progress notification");
+        }
+    }
+}
+
+/// Build a [`ChunkSink`] from a request's `_meta`.
+///
+/// Returns `Some(Arc<dyn ChunkSink>)` if the client supplied a
+/// `progressToken`, `None` otherwise. Tool handlers should pass the
+/// returned sink straight into `*_streaming` core functions.
+pub fn progress_sink_from_meta(
+    meta: &Meta,
+    peer: &Peer<RoleServer>,
+) -> Option<Arc<dyn ChunkSink>> {
+    meta.get_progress_token().map(|token| {
+        Arc::new(ProgressChunkSink {
+            peer: peer.clone(),
+            progress_token: token,
+            counter: AtomicU64::new(0),
+        }) as Arc<dyn ChunkSink>
+    })
 }

--- a/crates/devcontainer-mcp/src/tools/devcontainer/build.rs
+++ b/crates/devcontainer-mcp/src/tools/devcontainer/build.rs
@@ -1,8 +1,11 @@
 use devcontainer_mcp_core::devcontainer;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::{tool, tool_router};
+use rmcp::model::Meta;
+use rmcp::service::Peer;
+use rmcp::{tool, tool_router, RoleServer};
+use tokio_util::sync::CancellationToken;
 
-use crate::tools::common::format_output;
+use crate::tools::common::{format_output, progress_sink_from_meta};
 use crate::tools::DevContainerMcp;
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
@@ -24,6 +27,9 @@ impl DevContainerMcp {
     async fn devcontainer_build(
         &self,
         Parameters(params): Parameters<DevcontainerBuildParams>,
+        ct: CancellationToken,
+        peer: Peer<RoleServer>,
+        meta: Meta,
     ) -> String {
         let extra: Vec<String> = params
             .extra_args
@@ -31,7 +37,9 @@ impl DevContainerMcp {
             .and_then(shlex::split)
             .unwrap_or_default();
         let extra_refs: Vec<&str> = extra.iter().map(|s| s.as_str()).collect();
-        match devcontainer::build(&params.workspace_folder, &extra_refs).await {
+        let sink = progress_sink_from_meta(&meta, &peer);
+        match devcontainer::build_streaming(&params.workspace_folder, &extra_refs, &ct, sink).await
+        {
             Ok(output) => format_output(&output),
             Err(e) => format!("Error: {e}"),
         }

--- a/crates/devcontainer-mcp/src/tools/devcontainer/exec.rs
+++ b/crates/devcontainer-mcp/src/tools/devcontainer/exec.rs
@@ -1,6 +1,12 @@
+use std::sync::Arc;
+
+use devcontainer_mcp_core::cli::{ChunkSink, OutputChunk, OutputStream};
 use devcontainer_mcp_core::devcontainer;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::{tool, tool_router};
+use rmcp::model::{Meta, ProgressNotificationParam, ProgressToken};
+use rmcp::service::{Peer, RequestContext};
+use rmcp::{tool, tool_router, RoleServer};
+use tokio_util::sync::CancellationToken;
 
 use crate::tools::common::format_output;
 use crate::tools::DevContainerMcp;
@@ -15,6 +21,41 @@ struct DevcontainerExecParams {
     args: Option<String>,
 }
 
+/// Forwards every line of child output to the MCP peer as a
+/// `notifications/progress` message. Used to keep the wire warm during
+/// long-running execs (e.g. `go test -race`) so client-side watchdogs
+/// don't tear down the transport.
+struct ProgressChunkSink {
+    peer: Peer<RoleServer>,
+    progress_token: ProgressToken,
+    /// Monotonic counter so each notification has a strictly-increasing
+    /// `progress` value, as required by the MCP spec.
+    counter: std::sync::atomic::AtomicU64,
+}
+
+#[async_trait::async_trait]
+impl ChunkSink for ProgressChunkSink {
+    async fn on_chunk(&self, chunk: OutputChunk) {
+        let n = self
+            .counter
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        let prefix = match chunk.stream {
+            OutputStream::Stdout => "stdout",
+            OutputStream::Stderr => "stderr",
+        };
+        let param = ProgressNotificationParam::new(self.progress_token.clone(), n as f64)
+            .with_message(format!("{prefix}: {}", chunk.line));
+        if let Err(e) = self.peer.notify_progress(param).await {
+            // Sink errors are non-fatal: the peer may have disconnected
+            // or simply not subscribed to progress. We still want the
+            // child to keep running and produce a final response (which
+            // may or may not get delivered).
+            tracing::debug!(%e, "failed to send progress notification");
+        }
+    }
+}
+
 #[tool_router(router = devcontainer_exec_router, vis = "pub(super)")]
 impl DevContainerMcp {
     #[tool(
@@ -24,14 +65,44 @@ impl DevContainerMcp {
     async fn devcontainer_exec(
         &self,
         Parameters(params): Parameters<DevcontainerExecParams>,
+        ct: CancellationToken,
+        peer: Peer<RoleServer>,
+        meta: Meta,
     ) -> String {
         let full_cmd = match &params.args {
             Some(a) => format!("{} {}", params.command, a),
             None => params.command,
         };
-        match devcontainer::exec(&params.workspace_folder, "sh", &["-c", &full_cmd]).await {
+
+        // If the client supplied a progressToken in _meta, stream
+        // stdout/stderr to it as progress notifications. Otherwise just
+        // run with cancellation but no streaming.
+        let sink: Option<Arc<dyn ChunkSink>> = meta.get_progress_token().map(|token| {
+            Arc::new(ProgressChunkSink {
+                peer: peer.clone(),
+                progress_token: token,
+                counter: std::sync::atomic::AtomicU64::new(0),
+            }) as Arc<dyn ChunkSink>
+        });
+
+        match devcontainer::exec_streaming(
+            &params.workspace_folder,
+            "sh",
+            &["-c", &full_cmd],
+            &ct,
+            sink,
+        )
+        .await
+        {
             Ok(output) => format_output(&output),
             Err(e) => format!("Error: {e}"),
         }
     }
 }
+
+// `RequestContext` is not strictly required here — `CancellationToken`,
+// `Peer<RoleServer>`, and `Meta` are extracted directly by the tool_router
+// macro via their respective `FromContextPart` impls — but importing it
+// once keeps it discoverable for future tool authors.
+#[allow(dead_code)]
+fn _request_context_marker(_: RequestContext<RoleServer>) {}

--- a/crates/devcontainer-mcp/src/tools/devcontainer/exec.rs
+++ b/crates/devcontainer-mcp/src/tools/devcontainer/exec.rs
@@ -1,14 +1,11 @@
-use std::sync::Arc;
-
-use devcontainer_mcp_core::cli::{ChunkSink, OutputChunk, OutputStream};
 use devcontainer_mcp_core::devcontainer;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{Meta, ProgressNotificationParam, ProgressToken};
-use rmcp::service::{Peer, RequestContext};
+use rmcp::model::Meta;
+use rmcp::service::Peer;
 use rmcp::{tool, tool_router, RoleServer};
 use tokio_util::sync::CancellationToken;
 
-use crate::tools::common::format_output;
+use crate::tools::common::{format_output, progress_sink_from_meta};
 use crate::tools::DevContainerMcp;
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
@@ -19,41 +16,6 @@ struct DevcontainerExecParams {
     command: String,
     #[schemars(description = "Arguments for the command as a space-separated string")]
     args: Option<String>,
-}
-
-/// Forwards every line of child output to the MCP peer as a
-/// `notifications/progress` message. Used to keep the wire warm during
-/// long-running execs (e.g. `go test -race`) so client-side watchdogs
-/// don't tear down the transport.
-struct ProgressChunkSink {
-    peer: Peer<RoleServer>,
-    progress_token: ProgressToken,
-    /// Monotonic counter so each notification has a strictly-increasing
-    /// `progress` value, as required by the MCP spec.
-    counter: std::sync::atomic::AtomicU64,
-}
-
-#[async_trait::async_trait]
-impl ChunkSink for ProgressChunkSink {
-    async fn on_chunk(&self, chunk: OutputChunk) {
-        let n = self
-            .counter
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            + 1;
-        let prefix = match chunk.stream {
-            OutputStream::Stdout => "stdout",
-            OutputStream::Stderr => "stderr",
-        };
-        let param = ProgressNotificationParam::new(self.progress_token.clone(), n as f64)
-            .with_message(format!("{prefix}: {}", chunk.line));
-        if let Err(e) = self.peer.notify_progress(param).await {
-            // Sink errors are non-fatal: the peer may have disconnected
-            // or simply not subscribed to progress. We still want the
-            // child to keep running and produce a final response (which
-            // may or may not get delivered).
-            tracing::debug!(%e, "failed to send progress notification");
-        }
-    }
 }
 
 #[tool_router(router = devcontainer_exec_router, vis = "pub(super)")]
@@ -74,16 +36,7 @@ impl DevContainerMcp {
             None => params.command,
         };
 
-        // If the client supplied a progressToken in _meta, stream
-        // stdout/stderr to it as progress notifications. Otherwise just
-        // run with cancellation but no streaming.
-        let sink: Option<Arc<dyn ChunkSink>> = meta.get_progress_token().map(|token| {
-            Arc::new(ProgressChunkSink {
-                peer: peer.clone(),
-                progress_token: token,
-                counter: std::sync::atomic::AtomicU64::new(0),
-            }) as Arc<dyn ChunkSink>
-        });
+        let sink = progress_sink_from_meta(&meta, &peer);
 
         match devcontainer::exec_streaming(
             &params.workspace_folder,
@@ -99,10 +52,3 @@ impl DevContainerMcp {
         }
     }
 }
-
-// `RequestContext` is not strictly required here — `CancellationToken`,
-// `Peer<RoleServer>`, and `Meta` are extracted directly by the tool_router
-// macro via their respective `FromContextPart` impls — but importing it
-// once keeps it discoverable for future tool authors.
-#[allow(dead_code)]
-fn _request_context_marker(_: RequestContext<RoleServer>) {}

--- a/crates/devcontainer-mcp/src/tools/devcontainer/up.rs
+++ b/crates/devcontainer-mcp/src/tools/devcontainer/up.rs
@@ -1,8 +1,11 @@
 use devcontainer_mcp_core::devcontainer;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::{tool, tool_router};
+use rmcp::model::Meta;
+use rmcp::service::Peer;
+use rmcp::{tool, tool_router, RoleServer};
+use tokio_util::sync::CancellationToken;
 
-use crate::tools::common::format_output;
+use crate::tools::common::{format_output, progress_sink_from_meta};
 use crate::tools::DevContainerMcp;
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
@@ -28,6 +31,9 @@ impl DevContainerMcp {
     async fn devcontainer_up(
         &self,
         Parameters(params): Parameters<DevcontainerUpParams>,
+        ct: CancellationToken,
+        peer: Peer<RoleServer>,
+        meta: Meta,
     ) -> String {
         let extra: Vec<String> = params
             .extra_args
@@ -35,10 +41,13 @@ impl DevContainerMcp {
             .and_then(shlex::split)
             .unwrap_or_default();
         let extra_refs: Vec<&str> = extra.iter().map(|s| s.as_str()).collect();
-        match devcontainer::up(
+        let sink = progress_sink_from_meta(&meta, &peer);
+        match devcontainer::up_streaming(
             &params.workspace_folder,
             params.config.as_deref(),
             &extra_refs,
+            &ct,
+            sink,
         )
         .await
         {

--- a/crates/devcontainer-mcp/src/tools/devpod/build.rs
+++ b/crates/devcontainer-mcp/src/tools/devpod/build.rs
@@ -1,8 +1,12 @@
-use crate::tools::common::format_output;
-use crate::tools::DevContainerMcp;
 use devcontainer_mcp_core::devpod;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::{tool, tool_router};
+use rmcp::model::Meta;
+use rmcp::service::Peer;
+use rmcp::{tool, tool_router, RoleServer};
+use tokio_util::sync::CancellationToken;
+
+use crate::tools::common::{format_output, progress_sink_from_meta};
+use crate::tools::DevContainerMcp;
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
 struct DevpodBuildParams {
@@ -18,11 +22,18 @@ impl DevContainerMcp {
         name = "devpod_build",
         description = "Build a DevPod workspace image without starting it."
     )]
-    async fn devpod_build(&self, Parameters(params): Parameters<DevpodBuildParams>) -> String {
+    async fn devpod_build(
+        &self,
+        Parameters(params): Parameters<DevpodBuildParams>,
+        ct: CancellationToken,
+        peer: Peer<RoleServer>,
+        meta: Meta,
+    ) -> String {
         let parts: Vec<String> = shlex::split(&params.args)
             .unwrap_or_else(|| params.args.split_whitespace().map(String::from).collect());
         let part_refs: Vec<&str> = parts.iter().map(|s| s.as_str()).collect();
-        match devpod::build(&part_refs).await {
+        let sink = progress_sink_from_meta(&meta, &peer);
+        match devpod::build_streaming(&part_refs, &ct, sink).await {
             Ok(output) => format_output(&output),
             Err(e) => format!("Error: {e}"),
         }

--- a/crates/devcontainer-mcp/src/tools/devpod/ssh.rs
+++ b/crates/devcontainer-mcp/src/tools/devpod/ssh.rs
@@ -1,14 +1,11 @@
-use std::sync::Arc;
-
-use devcontainer_mcp_core::cli::{ChunkSink, OutputChunk, OutputStream};
 use devcontainer_mcp_core::devpod;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{Meta, ProgressNotificationParam, ProgressToken};
+use rmcp::model::Meta;
 use rmcp::service::Peer;
 use rmcp::{tool, tool_router, RoleServer};
 use tokio_util::sync::CancellationToken;
 
-use crate::tools::common::format_output;
+use crate::tools::common::{format_output, progress_sink_from_meta};
 use crate::tools::DevContainerMcp;
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
@@ -25,34 +22,6 @@ struct DevpodSshParams {
     workdir: Option<String>,
 }
 
-/// Forwards every line of child output to the MCP peer as a
-/// `notifications/progress` message, keeping the transport warm during
-/// long-running execs.
-struct ProgressChunkSink {
-    peer: Peer<RoleServer>,
-    progress_token: ProgressToken,
-    counter: std::sync::atomic::AtomicU64,
-}
-
-#[async_trait::async_trait]
-impl ChunkSink for ProgressChunkSink {
-    async fn on_chunk(&self, chunk: OutputChunk) {
-        let n = self
-            .counter
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            + 1;
-        let prefix = match chunk.stream {
-            OutputStream::Stdout => "stdout",
-            OutputStream::Stderr => "stderr",
-        };
-        let param = ProgressNotificationParam::new(self.progress_token.clone(), n as f64)
-            .with_message(format!("{prefix}: {}", chunk.line));
-        if let Err(e) = self.peer.notify_progress(param).await {
-            tracing::debug!(%e, "failed to send progress notification");
-        }
-    }
-}
-
 #[tool_router(router = devpod_ssh_router, vis = "pub(super)")]
 impl DevContainerMcp {
     #[tool(
@@ -66,13 +35,7 @@ impl DevContainerMcp {
         peer: Peer<RoleServer>,
         meta: Meta,
     ) -> String {
-        let sink: Option<Arc<dyn ChunkSink>> = meta.get_progress_token().map(|token| {
-            Arc::new(ProgressChunkSink {
-                peer: peer.clone(),
-                progress_token: token,
-                counter: std::sync::atomic::AtomicU64::new(0),
-            }) as Arc<dyn ChunkSink>
-        });
+        let sink = progress_sink_from_meta(&meta, &peer);
 
         match devpod::ssh_exec_streaming(
             &params.workspace,

--- a/crates/devcontainer-mcp/src/tools/devpod/ssh.rs
+++ b/crates/devcontainer-mcp/src/tools/devpod/ssh.rs
@@ -1,8 +1,15 @@
-use crate::tools::common::format_output;
-use crate::tools::DevContainerMcp;
+use std::sync::Arc;
+
+use devcontainer_mcp_core::cli::{ChunkSink, OutputChunk, OutputStream};
 use devcontainer_mcp_core::devpod;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::{tool, tool_router};
+use rmcp::model::{Meta, ProgressNotificationParam, ProgressToken};
+use rmcp::service::Peer;
+use rmcp::{tool, tool_router, RoleServer};
+use tokio_util::sync::CancellationToken;
+
+use crate::tools::common::format_output;
+use crate::tools::DevContainerMcp;
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
 struct DevpodSshParams {
@@ -18,18 +25,62 @@ struct DevpodSshParams {
     workdir: Option<String>,
 }
 
+/// Forwards every line of child output to the MCP peer as a
+/// `notifications/progress` message, keeping the transport warm during
+/// long-running execs.
+struct ProgressChunkSink {
+    peer: Peer<RoleServer>,
+    progress_token: ProgressToken,
+    counter: std::sync::atomic::AtomicU64,
+}
+
+#[async_trait::async_trait]
+impl ChunkSink for ProgressChunkSink {
+    async fn on_chunk(&self, chunk: OutputChunk) {
+        let n = self
+            .counter
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        let prefix = match chunk.stream {
+            OutputStream::Stdout => "stdout",
+            OutputStream::Stderr => "stderr",
+        };
+        let param = ProgressNotificationParam::new(self.progress_token.clone(), n as f64)
+            .with_message(format!("{prefix}: {}", chunk.line));
+        if let Err(e) = self.peer.notify_progress(param).await {
+            tracing::debug!(%e, "failed to send progress notification");
+        }
+    }
+}
+
 #[tool_router(router = devpod_ssh_router, vis = "pub(super)")]
 impl DevContainerMcp {
     #[tool(
         name = "devpod_ssh",
         description = "Execute a command inside a DevPod workspace via SSH. Returns stdout, stderr, and exit code."
     )]
-    async fn devpod_ssh(&self, Parameters(params): Parameters<DevpodSshParams>) -> String {
-        match devpod::ssh_exec(
+    async fn devpod_ssh(
+        &self,
+        Parameters(params): Parameters<DevpodSshParams>,
+        ct: CancellationToken,
+        peer: Peer<RoleServer>,
+        meta: Meta,
+    ) -> String {
+        let sink: Option<Arc<dyn ChunkSink>> = meta.get_progress_token().map(|token| {
+            Arc::new(ProgressChunkSink {
+                peer: peer.clone(),
+                progress_token: token,
+                counter: std::sync::atomic::AtomicU64::new(0),
+            }) as Arc<dyn ChunkSink>
+        });
+
+        match devpod::ssh_exec_streaming(
             &params.workspace,
             &params.command,
             params.user.as_deref(),
             params.workdir.as_deref(),
+            &ct,
+            sink,
         )
         .await
         {

--- a/crates/devcontainer-mcp/src/tools/devpod/up.rs
+++ b/crates/devcontainer-mcp/src/tools/devpod/up.rs
@@ -1,8 +1,12 @@
-use crate::tools::common::format_output;
-use crate::tools::DevContainerMcp;
 use devcontainer_mcp_core::devpod;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::{tool, tool_router};
+use rmcp::model::Meta;
+use rmcp::service::Peer;
+use rmcp::{tool, tool_router, RoleServer};
+use tokio_util::sync::CancellationToken;
+
+use crate::tools::common::{format_output, progress_sink_from_meta};
+use crate::tools::DevContainerMcp;
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
 struct DevpodUpParams {
@@ -18,11 +22,18 @@ impl DevContainerMcp {
         name = "devpod_up",
         description = "Create and start a DevPod workspace. Pass the source (git URL, local path, or image) and any flags as space-separated args. Returns full build output for self-healing."
     )]
-    async fn devpod_up(&self, Parameters(params): Parameters<DevpodUpParams>) -> String {
+    async fn devpod_up(
+        &self,
+        Parameters(params): Parameters<DevpodUpParams>,
+        ct: CancellationToken,
+        peer: Peer<RoleServer>,
+        meta: Meta,
+    ) -> String {
         let parts: Vec<String> = shlex::split(&params.args)
             .unwrap_or_else(|| params.args.split_whitespace().map(String::from).collect());
         let part_refs: Vec<&str> = parts.iter().map(|s| s.as_str()).collect();
-        match devpod::up(&part_refs).await {
+        let sink = progress_sink_from_meta(&meta, &peer);
+        match devpod::up_streaming(&part_refs, &ct, sink).await {
             Ok(output) => format_output(&output),
             Err(e) => format!("Error: {e}"),
         }


### PR DESCRIPTION
## Summary

A user reported that `devcontainer_exec` returned `MCP error -32000: Connection closed` when an agent fired several parallel calls. Investigating turned up four real server-side defects in our long-running tool path; this PR fixes all four across all three backends.

| Defect | Visible symptom |
|---|---|
| Output buffered until child exits | Wire silent for minutes; client idle watchdogs trip during `go test -race` |
| Cancellation ignored | `notifications/cancelled` arrives → handler keeps running, child keeps running |
| Cross-boundary descendants survive cancel | `go test -race` continues eating a core inside the container after we "stopped" |
| Lifecycle tools (`*_up`, `*_build`, `codespaces_create`) ignore cancellation entirely | Wasted a GCE VM during my own testing — that's what surfaced this |

Verified live against:
- local docker (devcontainer backend)
- live GitHub Codespace on `basicLinux32gb`
- live GCE workspace via DevPod's `gcloud` provider (both `devpod_ssh` and `devpod_up`)

## Fix shape

For every long-running tool (3 exec/ssh + 5 lifecycle = 8 total), the handler now:

1. Spawns the child with piped stdout/stderr and `kill_on_drop(true)`.
2. Streams each line to the client as `notifications/progress` (if a `progressToken` is in `_meta`), and accumulates it into the final `CliOutput`.
3. Awaits the child concurrently with the rmcp-provided `CancellationToken`.
4. On cancel: kills the child's process group, then for cross-boundary backends ALSO kills the in-target process group via a backend-specific `RemoteKiller`.

### Crossing process boundaries

`/proc` walks the host PID tree but **the docker daemon reparents in-container processes under containerd-shim, hiding them from our ancestry**. The same is true for SSH — the remote `sshd` reparents under PID 1 on the target. So we can't reach in-target descendants by walking host ancestry.

Instead, before running the user's command we wrap it with a tiny shell shim:

```sh
setsid sh -c 'printf "__DCMCP_PGID=%s__\n" "$$" 1>&2; eval "$DCMCP_USER_CMD"' &
wait $!
exit "$?"
```

- `setsid` puts the leaf shell in a fresh session, so its PID is also its **PGID**, and the PGID transitively addresses every descendant.
- The sentinel publishes the PGID on stderr; the host-side stderr reader captures it (and strips the sentinel line from the user-visible stderr).
- `eval "$DCMCP_USER_CMD"` runs the user command in the same shell, so the PGID stays stable.

On cancel, a per-backend `RemoteKiller` sends `kill -TERM -<pgid>` then `kill -KILL -<pgid>` *into the target*:

- **devcontainer**: bollard `create_exec` (no extra docker exec hop).
- **devpod**: fresh `devpod ssh --command "kill ..."`.
- **codespaces**: fresh `gh codespace ssh -c <cs> -- "kill ..."`.

The shim has two flavors:
- `wrap()` — reads the user command from env (`DCMCP_USER_CMD`). Used for `devcontainer exec` which has `--remote-env`.
- `wrap_self_contained(user_cmd)` — embeds the user command as a base64 blob inside the shell snippet, no env propagation needed. Used for SSH-based backends.

The base64 path was the cleanest answer to "what if the user command contains single quotes, parens, subshells, arithmetic, newlines" — there's a unit test for that exact case.

## Shared infrastructure (new in `core`)

- **`cli::run_cli_streaming`** — spawn + concurrent line-by-line capture + cancel via `process_tree::reap`. For host-only CLIs (`devpod up`, `devcontainer build`, `gh codespace create`).
- **`cli::run_with_shim`** — same plus stderr sentinel capture + on-cancel callback to a `RemoteKiller`. For cross-boundary CLIs.
- **`cli::RemoteKiller`** trait — three backends implement it (`DevcontainerKiller`, `DevpodKiller`, `CodespaceKiller`).
- **`process_tree::reap(pid, grace)`** — BFS `/proc/<pid>/status` for descendants, SIGTERM all, wait grace, SIGKILL survivors. Used for the host side regardless of backend.
- **`exec_shim::wrap()` / `wrap_self_contained()` / `try_parse_sentinel()`** — the shim primitives.

## Subtle bugs found during live verification

1. **`setsid` exits without waiting** — first iteration used `exec setsid sh -c '...'`; setsid forked and the parent exited immediately. `devpod up` thought the work was done while the in-container processes kept running. Fix: background + `wait $!` instead of `exec setsid` (POSIX, works on BusyBox/dash; `setsid -w` is util-linux-only).
2. **`kill -- -PGID` rejected by BusyBox** — slim container images ship BusyBox `kill` which rejects the POSIX `--` separator. Fix: bare `kill -TERM -PGID`.
3. **Sentinel parser missed decorated lines** — `devpod ssh` prefixes remote stderr with `[time] info `+ ANSI color codes, so a strict `line.trim() == "__DCMCP_PGID=N__"` parser never matched. Fix: search for the sentinel anywhere within a line. The `__DCMCP_*__` delimiters are distinctive enough that false positives are effectively impossible; there's a unit test covering both decorated and plain forms, and tightened rejection tests for truncated/empty/non-numeric input.
4. **Lifecycle tools weren't cancellable at all** — opencode's 60s client default timed me out mid-`devpod up`, our handler kept running, GCE VM kept provisioning, billing kept going. Cost me a few cents and shipped the fix to all five lifecycle tools.

## Verification matrix

| backend × scenario | result |
|---|---|
| `devcontainer_exec`, 3× parallel `go test -race` / `vet` / `build` | 17s, all responses correct, server stays up |
| `devcontainer_exec`, in-container nested-sleep tree (5 procs) cancelled | 5 → 0 reaped via bollard `create_exec` kill |
| `devcontainer_exec`, progress streaming over 3s | 5 live notifications |
| `codespaces_ssh`, progress streaming over 5s | 5 live notifications |
| `codespaces_ssh`, nested-sleep tree (3 procs) cancelled | 3 → 0 reaped via `gh codespace ssh` kill |
| `devpod_ssh`, progress streaming over 5s | 7 live notifications |
| `devpod_ssh`, nested-sleep tree (3 procs) cancelled | 3 → 0 reaped via `devpod ssh` kill |
| `devpod_up`, 45s of GCE provisioning | 114 progress notifications |
| `devpod_up`, cancelled mid-provision | returned in 2s; explicit `devpod delete` clean; `gcloud instances list` empty |

Unit tests: 21 in core (was 9) + 10 hook-guard, all passing. New tests cover the shim wrap/parse paths, the PATH-shim end-to-end of `run_with_shim` + `RemoteKiller` ordering, and the decorated-line sentinel matching.

## Known follow-ups (out of scope)

- **Cancel latency on SSH backends** is ~25s because each `kill` goes through a fresh SSH handshake and we do it twice (TERM, 2s grace, KILL). Could collapse to one session: `kill -TERM -N; sleep 2; kill -KILL -N`. Brings devpod/codespaces cancel to ~3-5s.
- **`devpod_provider_add` tool** rejects short provider names like `gcloud` even though the underlying CLI accepts them. Found this when setting up the gcloud provider for live testing.
- **Idle-stdin self-termination**: when a misbehaving client abandons our stdio without closing it, we sit on an open socket forever. Already saw three orphans on the test machine. A periodic "no requests in N minutes → exit" watchdog would clean them up.

## Commits

- `e2da52f` devcontainer exec: stream output, support cancellation, reap container descendants
- `89d8694` devpod + codespaces ssh: stream output, support cancellation, reap remote PGID
- `48e8eab` lifecycle tools: stream + honor cancellation; sentinel parser accepts decorated lines
