### PR TITLE
install.sh: auto-install devcontainer CLI via standalone bundle

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,12 @@ set -euo pipefail
 
 # devcontainer-mcp installer
 # Downloads the latest release binary.
-# Backend CLIs (devpod, devcontainer, gh) are detected at runtime —
-# if missing, the MCP server returns a helpful error message.
+# Backend CLIs:
+#   - devcontainer (@devcontainers/cli) is auto-installed via the official
+#     standalone installer (bundles its own Node.js runtime) into
+#     ~/.local/share/devcontainer-mcp/devcontainers/ when missing.
+#   - devpod and gh are detected only; if missing, the MCP server returns
+#     a helpful error message and the installer prints install URLs.
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/aniongithub/devcontainer-mcp/main/install.sh | bash
@@ -295,7 +299,35 @@ configure_copilot_hook
 echo ""
 echo "Backend CLIs detected (install as needed — MCP server gives helpful errors if missing):"
 command -v devpod       >/dev/null 2>&1 && echo "  ✓ devpod"       || echo "  ✗ devpod        — https://devpod.sh/docs/getting-started/install"
-command -v devcontainer >/dev/null 2>&1 && echo "  ✓ devcontainer"  || echo "  ✗ devcontainer   — https://github.com/devcontainers/cli#install-script"
+
+# devcontainer CLI: auto-install via the official standalone installer
+# (bundles its own Node.js runtime — no system Node required) into a
+# folder we own, then symlink the binary into INSTALL_DIR so it picks
+# up the same PATH guidance the script gives for the main binary.
+install_devcontainer_cli() {
+  local cli_prefix="${HOME}/.local/share/devcontainer-mcp/devcontainers"
+  local installer_url="https://raw.githubusercontent.com/devcontainers/cli/main/scripts/install.sh"
+  echo "  … devcontainer CLI not found — installing standalone bundle into ${cli_prefix}"
+  mkdir -p "$(dirname "$cli_prefix")"
+  if ! curl -fsSL "$installer_url" | sh -s -- --prefix "$cli_prefix" >/dev/null 2>&1; then
+    echo "  ✗ devcontainer   — standalone install failed; see https://github.com/devcontainers/cli#install-script"
+    return 1
+  fi
+  local shim="${cli_prefix}/bin/devcontainer"
+  if [ ! -x "$shim" ]; then
+    echo "  ✗ devcontainer   — install completed but ${shim} is missing"
+    return 1
+  fi
+  ln -sf "$shim" "${INSTALL_DIR}/devcontainer"
+  echo "  ✓ devcontainer (auto-installed → ${INSTALL_DIR}/devcontainer)"
+}
+
+if command -v devcontainer >/dev/null 2>&1; then
+  echo "  ✓ devcontainer"
+else
+  install_devcontainer_cli || true
+fi
+
 command -v gh           >/dev/null 2>&1 && echo "  ✓ gh (codespaces)" || echo "  ✗ gh (codespaces) — https://cli.github.com/"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
When the devcontainer CLI is missing, the installer now bootstraps it via the official [@devcontainers/cli standalone installer](https://github.com/devcontainers/cli/blob/main/scripts/install.sh), which bundles its own Node.js runtime — so no system Node is required.

## Behavior

- Installs into `~/.local/share/devcontainer-mcp/devcontainers/` (a folder we own, kept separate from the user's other tools).
- Symlinks the resulting binary into `$INSTALL_DIR/devcontainer` so it sits on the same PATH line the installer already tells users to add.
- Pre-creates the parent dir so the upstream installer's parent-writable check passes on fresh systems.
- **Failure is non-fatal**: prints a pointer to the upstream install script and continues. `devpod` and `gh` remain detect-only (out of scope).

`install.ps1` delegates to `install.sh` inside WSL, so Windows users get the auto-install for free.

## Verification

Tested locally with a clean `HOME` + `INSTALL_DIR`:

```
… devcontainer CLI not found — installing standalone bundle into …/devcontainers
  ✓ devcontainer (auto-installed → …/devcontainer)
0.87.0
```

Closes the gap where the prior installer just printed `✗ devcontainer — https://…` and left the user to figure it out, even though the only blocker was a one-shot download.