### PR TITLE
Add MCP Registry publishing on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,12 @@ on:
   release:
     types: [created]
 
-permissions:
-  contents: write
-
 jobs:
   build:
     name: Build release binaries
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
 
@@ -49,6 +48,8 @@ jobs:
   build-macos:
     name: Build ${{ matrix.artifact }}
     runs-on: macos-latest
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:
@@ -80,6 +81,8 @@ jobs:
   upload-install-script:
     name: Upload install scripts
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
       - name: Upload install.sh and install.ps1
@@ -88,3 +91,49 @@ jobs:
           files: |
             install.sh
             install.ps1
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    needs: [build, build-macos]
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry (OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Patch server.json with version, URLs, and SHA-256 hashes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          BASE="https://github.com/aniongithub/devcontainer-mcp/releases/download/${TAG}"
+
+          # Set top-level version
+          jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
+
+          # Download each platform artifact, compute SHA-256, patch identifier + hash
+          PLATFORMS=("linux-x64" "linux-arm64" "darwin-x64" "darwin-arm64")
+          for platform in "${PLATFORMS[@]}"; do
+            FILE="devcontainer-mcp-${platform}.tar.gz"
+            curl -fsSL --retry 5 --retry-delay 3 -o "$FILE" "${BASE}/${FILE}"
+            SHA="$(sha256sum "$FILE" | awk '{print $1}')"
+            URL="${BASE}/${FILE}"
+            jq --arg platform "$platform" --arg url "$URL" --arg sha "$SHA" \
+              '(.packages[] | select(.identifier | contains($platform))) |= (.identifier = $url | .fileSha256 = $sha)' \
+              server.json > server.tmp && mv server.tmp server.json
+          done
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.aniongithub/devcontainer-mcp",
+  "title": "devcontainer-mcp",
+  "description": "MCP server that lets AI agents create, manage, and work inside dev containers across Docker, DevPod, and GitHub Codespaces.",
+  "repository": {
+    "url": "https://github.com/aniongithub/devcontainer-mcp",
+    "source": "github"
+  },
+  "version": "0.0.0",
+  "packages": [
+    {
+      "registryType": "mcpb",
+      "identifier": "https://github.com/aniongithub/devcontainer-mcp/releases/download/v0.0.0/devcontainer-mcp-linux-x64.tar.gz",
+      "fileSha256": "PLACEHOLDER",
+      "transport": { "type": "stdio" }
+    },
+    {
+      "registryType": "mcpb",
+      "identifier": "https://github.com/aniongithub/devcontainer-mcp/releases/download/v0.0.0/devcontainer-mcp-linux-arm64.tar.gz",
+      "fileSha256": "PLACEHOLDER",
+      "transport": { "type": "stdio" }
+    },
+    {
+      "registryType": "mcpb",
+      "identifier": "https://github.com/aniongithub/devcontainer-mcp/releases/download/v0.0.0/devcontainer-mcp-darwin-x64.tar.gz",
+      "fileSha256": "PLACEHOLDER",
+      "transport": { "type": "stdio" }
+    },
+    {
+      "registryType": "mcpb",
+      "identifier": "https://github.com/aniongithub/devcontainer-mcp/releases/download/v0.0.0/devcontainer-mcp-darwin-arm64.tar.gz",
+      "fileSha256": "PLACEHOLDER",
+      "transport": { "type": "stdio" }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Publishes `devcontainer-mcp` to the [MCP Registry](https://registry.modelcontextprotocol.io) automatically on every GitHub release using the **MCPB** (prebuilt binary) package type.

## Changes

### `server.json` (new)
MCP Registry metadata file with MCPB entries for all 4 platforms (linux-x64, linux-arm64, darwin-x64, darwin-arm64). Contains placeholder version/hashes that CI patches at release time.

Server name: `io.github.aniongithub/devcontainer-mcp`

### `.github/workflows/release.yml` (updated)
- **Moved** permissions from workflow-level to per-job (principle of least privilege)
- **Added** `publish-mcp-registry` job:
  - Runs after `build` and `build-macos` complete
  - Uses **OIDC auth** (`id-token: write`) — no secrets to manage
  - Downloads release artifacts with retries, computes SHA-256 hashes
  - Patches `server.json` with real version, URLs, and hashes
  - Publishes via `mcp-publisher` CLI

## How it works

1. Build jobs upload platform tarballs to the GitHub release (existing behavior)
2. New `publish-mcp-registry` job downloads those tarballs, hashes them, and publishes metadata to the MCP Registry
3. Users can then install via: `mcp install io.github.aniongithub/devcontainer-mcp`

## First-time setup

After merging, the first release will attempt OIDC auth with the registry. If this is the first publish for this server name, a manual first publish may be needed to claim the name (see [mind-map notes](https://registry.modelcontextprotocol.io) for details).